### PR TITLE
Wait for all examples to process before exiting a worker

### DIFF
--- a/lib/specwrk/worker.rb
+++ b/lib/specwrk/worker.rb
@@ -29,9 +29,13 @@ module Specwrk
         break if Specwrk.force_quit
 
         execute
-      rescue CompletedAllExamplesError, NoMoreExamplesError
-        # TODO: Sleep on NoMoreExamplesError to allow for retries
+      rescue CompletedAllExamplesError
         break
+      rescue NoMoreExamplesError
+        # Wait for the other processes (workers) on the same host to finish
+        # This will cause workers to 'hang' until all work has been completed
+        # TODO: break here if all the other worker processes on this host are done executing examples
+        sleep 0.5
       end
 
       executor.final_output.tap(&:rewind).each_line { |line| $stdout.write line }

--- a/spec/specwrk/worker_spec.rb
+++ b/spec/specwrk/worker_spec.rb
@@ -104,14 +104,21 @@ RSpec.describe Specwrk::Worker do
     context "calls run_examples until NoMoreExamplesError" do
       before { allow(Specwrk::Client).to receive(:wait_for_server!) }
 
-      it "breaks the loop" do
-        count = 1
-        expect(instance).to receive(:execute).exactly(5).times do
-          if count == 5
-            raise Specwrk::NoMoreExamplesError
-          end
+      it "sleeps but doesn't break loop" do
+        expect(instance).to receive(:sleep)
+          .with(0.5)
+          .exactly(4).times
 
+        count = 0
+        expect(instance).to receive(:execute).exactly(5).times do
           count += 1
+
+          if count < 5
+            raise Specwrk::NoMoreExamplesError
+          else
+            # breaks the loop
+            raise Specwrk::CompletedAllExamplesError
+          end
         end
 
         expect($stdout).to receive(:write)


### PR DESCRIPTION
If we exit a worker process early, when there are no more examples in the queue, the worker will drain its final output to STDOUT. This is fine if there is only one worker process running, however, if there is another worker process which isn't done yet, we'll get some garbled output.

+ This will allow for future retries should the last example get pushed back into the pending queue