### PR TITLE
Assign Specwrk.net_http to Net::HTTP before Webmock can mock it

### DIFF
--- a/lib/specwrk.rb
+++ b/lib/specwrk.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "specwrk/version"
+require "specwrk/version"
 
 module Specwrk
   Error = Class.new(StandardError)
@@ -15,7 +15,7 @@ module Specwrk
   @starting_pid = Process.pid
 
   class << self
-    attr_accessor :force_quit
+    attr_accessor :force_quit, :net_http
     attr_reader :starting_pid
 
     def wait_for_pids_exit(pids)

--- a/lib/specwrk/client.rb
+++ b/lib/specwrk/client.rb
@@ -4,6 +4,12 @@ require "uri"
 require "net/http"
 require "json"
 
+require "specwrk"
+
+# Some rspec setups might use webmock, which intercepts specwrk server calls
+# Let's capture the OG HTTP before that happens
+Specwrk.net_http = Net::HTTP
+
 module Specwrk
   class Client
     def self.connect?
@@ -18,7 +24,7 @@ module Specwrk
 
     def self.build_http
       uri = URI(ENV.fetch("SPECWRK_SRV_URI", "http://localhost:5138"))
-      Net::HTTP.new(uri.host, uri.port).tap do |http|
+      Specwrk.net_http.new(uri.host, uri.port).tap do |http|
         http.use_ssl = uri.scheme == "https"
         http.open_timeout = ENV.fetch("SPECWRK_TIMEOUT", "5").to_i
         http.read_timeout = ENV.fetch("SPECWRK_TIMEOUT", "5").to_i
@@ -106,28 +112,28 @@ module Specwrk
     private
 
     def get(path, headers: default_headers, body: nil)
-      request = Net::HTTP::Get.new(path, headers)
+      request = Specwrk.net_http::Get.new(path, headers)
       request.body = body if body
 
       make_request(request)
     end
 
     def post(path, headers: default_headers, body: nil)
-      request = Net::HTTP::Post.new(path, headers)
+      request = Specwrk.net_http::Post.new(path, headers)
       request.body = body if body
 
       make_request(request)
     end
 
     def put(path, headers: default_headers, body: nil)
-      request = Net::HTTP::Put.new(path, headers)
+      request = Specwrk.net_http::Put.new(path, headers)
       request.body = body if body
 
       make_request(request)
     end
 
     def delete(path, headers: default_headers, body: nil)
-      request = Net::HTTP::Delete.new(path, headers)
+      request = Specwrk.net_http::Delete.new(path, headers)
       request.body = body if body
 
       make_request(request)

--- a/spec/specwrk/client_spec.rb
+++ b/spec/specwrk/client_spec.rb
@@ -7,6 +7,15 @@ RSpec.describe Specwrk::Client do
   let(:srv_key) { "secret-key" }
   let(:run_id) { "run-123" }
 
+  around do |ex|
+    previous_net_http = Specwrk.net_http
+    Specwrk.net_http = Net::HTTP
+
+    ex.run
+
+    Specwrk.net_http = previous_net_http
+  end
+
   before do
     stub_const("ENV", ENV.to_h.merge(
       "SPECWRK_SRV_URI" => base_uri,


### PR DESCRIPTION
Fixes #21