### PR TITLE
Track if the worker has processed *any* examples

### DIFF
--- a/lib/specwrk.rb
+++ b/lib/specwrk.rb
@@ -8,6 +8,7 @@ module Specwrk
   # HTTP Client Errors
   ClientError = Class.new(Error)
   UnhandledResponseError = Class.new(ClientError)
+  WaitingForSeedError = Class.new(ClientError)
   NoMoreExamplesError = Class.new(ClientError)
   CompletedAllExamplesError = Class.new(ClientError)
 

--- a/lib/specwrk/client.rb
+++ b/lib/specwrk/client.rb
@@ -88,6 +88,8 @@ module Specwrk
       case response.code
       when "200"
         JSON.parse(response.body, symbolize_names: true)
+      when "204"
+        raise WaitingForSeedError
       when "404"
         raise NoMoreExamplesError
       when "410"

--- a/lib/specwrk/web/endpoints.rb
+++ b/lib/specwrk/web/endpoints.rb
@@ -94,7 +94,9 @@ module Specwrk
 
           if @examples.length.positive?
             [200, {"Content-Type" => "application/json"}, [JSON.generate(@examples)]]
-          elsif processing_queue.length.zero?
+          elsif pending_queue.length.zero? && processing_queue.length.zero? && completed_queue.length.zero?
+            [204, {"Content-Type" => "text/plain"}, ["Waiting for sample to be seeded."]]
+          elsif completed_queue.length.positive? && processing_queue.length.zero?
             [410, {"Content-Type" => "text/plain"}, ["That's a good lad. Run along now and go home."]]
           else
             not_found

--- a/lib/specwrk/worker.rb
+++ b/lib/specwrk/worker.rb
@@ -36,6 +36,17 @@ module Specwrk
         # This will cause workers to 'hang' until all work has been completed
         # TODO: break here if all the other worker processes on this host are done executing examples
         sleep 0.5
+      rescue WaitingForSeedError
+        @seed_wait_count ||= 0
+        @seed_wait_count += 1
+
+        if @seed_wait_count <= 10
+          warn "No examples seeded yet, waiting..."
+          sleep 1
+        else
+          warn "No examples seeded, giving up!"
+          break
+        end
       end
 
       executor.final_output.tap(&:rewind).each_line { |line| $stdout.write line }

--- a/lib/specwrk/worker.rb
+++ b/lib/specwrk/worker.rb
@@ -88,6 +88,7 @@ module Specwrk
     attr_reader :running, :client, :executor
 
     def status
+      return 1 unless executor.example_processed
       return 1 if executor.failure
       return 1 if Specwrk.force_quit
 

--- a/lib/specwrk/worker/executor.rb
+++ b/lib/specwrk/worker/executor.rb
@@ -11,6 +11,8 @@ require "specwrk/worker/null_formatter"
 module Specwrk
   class Worker
     class Executor
+      attr_reader :example_processed
+
       def failure
         completion_formatter.failure
       end
@@ -27,6 +29,7 @@ module Specwrk
         reset!
 
         example_ids = examples.map { |example| example[:id] }
+        @example_processed ||= true unless example_ids.size.zero? # only ever toggle from nil => true
 
         options = RSpec::Core::ConfigurationOptions.new rspec_options + example_ids
         RSpec::Core::Runner.new(options).run($stderr, $stdout)

--- a/spec/specwrk/client_spec.rb
+++ b/spec/specwrk/client_spec.rb
@@ -175,6 +175,15 @@ RSpec.describe Specwrk::Client do
       it { is_expected.to eq(examples) }
     end
 
+    context "when response is 204" do
+      before do
+        stub_request(:post, "#{base_uri}/pop").to_return(status: 204)
+      end
+
+      it "raises WaitingForSeedError" do
+        expect { subject }.to raise_error(Specwrk::WaitingForSeedError)
+      end
+    end
     context "when response is 404" do
       before do
         stub_request(:post, "#{base_uri}/pop").to_return(status: 404)

--- a/spec/specwrk/web/endpoints_spec.rb
+++ b/spec/specwrk/web/endpoints_spec.rb
@@ -99,14 +99,20 @@ RSpec.describe Specwrk::Web::Endpoints do
       it { expect { subject }.to change(processing_queue, :length).from(0).to(1) }
     end
 
+    context "no items in any queue" do
+      it { is_expected.to eq([204, {"Content-Type" => "text/plain"}, ["Waiting for sample to be seeded."]]) }
+    end
+
+    context "no items in the processing queue, but completed queue has items" do
+      before { completed_queue.merge!(2 => {id: 2, expected_run_time: 0}) }
+
+      it { is_expected.to eq([410, {"Content-Type" => "text/plain"}, ["That's a good lad. Run along now and go home."]]) }
+    end
+
     context "no items in the pending queue, but something in the processing queue" do
       before { processing_queue.merge!(2 => {id: 2, expected_run_time: 0}) }
 
       it { is_expected.to eq([404, {"Content-Type" => "text/plain"}, ["This is not the path you're looking for, 'ol chap..."]]) }
-    end
-
-    context "no items in the pending queue, no items in the processing queue" do
-      it { is_expected.to eq([410, {"Content-Type" => "text/plain"}, ["That's a good lad. Run along now and go home."]]) }
     end
   end
 end

--- a/spec/specwrk/worker/executor_spec.rb
+++ b/spec/specwrk/worker/executor_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Specwrk::Worker::Executor do
         .and_return("🇺🇸!Big Success!🇺🇸")
 
       expect(instance.run(examples)).to eq("🇺🇸!Big Success!🇺🇸")
+      expect(instance.example_processed).to eq(true)
     end
   end
 

--- a/spec/specwrk/worker_spec.rb
+++ b/spec/specwrk/worker_spec.rb
@@ -125,6 +125,31 @@ RSpec.describe Specwrk::Worker do
       end
     end
 
+    context "calls run_examples when WaitingForSeedError" do
+      let(:example_processed) { nil }
+
+      before { allow(Specwrk::Client).to receive(:wait_for_server!) }
+
+      it "waits up to 10s before exiting" do
+        expect(instance).to receive(:sleep)
+          .with(1)
+          .exactly(10).times
+
+        expect(instance).to receive(:execute)
+          .and_raise(Specwrk::WaitingForSeedError)
+          .exactly(11).times
+
+        expect(instance).to receive(:warn)
+          .with("No examples seeded yet, waiting...")
+          .exactly(10).times
+
+        expect(instance).to receive(:warn)
+          .with("No examples seeded, giving up!")
+
+        expect(subject).to eq(1)
+      end
+    end
+
     context "calls run_examples until NoMoreExamplesError" do
       before { allow(Specwrk::Client).to receive(:wait_for_server!) }
 


### PR DESCRIPTION
Return 1 (eventual exit 1) when no examples have been processed.

Fixes #25