### PR TITLE
Track if the worker has processed *any* examples

### DIFF
--- a/lib/specwrk/worker.rb
+++ b/lib/specwrk/worker.rb
@@ -88,6 +88,7 @@ module Specwrk
     attr_reader :running, :client, :executor
 
     def status
+      return 1 unless executor.example_processed
       return 1 if executor.failure
       return 1 if Specwrk.force_quit
 

--- a/lib/specwrk/worker/executor.rb
+++ b/lib/specwrk/worker/executor.rb
@@ -11,6 +11,8 @@ require "specwrk/worker/null_formatter"
 module Specwrk
   class Worker
     class Executor
+      attr_reader :example_processed
+
       def failure
         completion_formatter.failure
       end
@@ -27,6 +29,7 @@ module Specwrk
         reset!
 
         example_ids = examples.map { |example| example[:id] }
+        @example_processed ||= true unless example_ids.size.zero? # only ever toggle from nil => true
 
         options = RSpec::Core::ConfigurationOptions.new rspec_options + example_ids
         RSpec::Core::Runner.new(options).run($stderr, $stdout)

--- a/spec/specwrk/worker/executor_spec.rb
+++ b/spec/specwrk/worker/executor_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Specwrk::Worker::Executor do
         .and_return("🇺🇸!Big Success!🇺🇸")
 
       expect(instance.run(examples)).to eq("🇺🇸!Big Success!🇺🇸")
+      expect(instance.example_processed).to eq(true)
     end
   end
 


### PR DESCRIPTION
Return 1 (eventual exit 1) when no examples have been processed.

Fixes #25