### PR TITLE
Don't dump the completed queue if its empty

### DIFF
--- a/spec/specwrk/web/endpoints_spec.rb
+++ b/spec/specwrk/web/endpoints_spec.rb
@@ -98,6 +98,21 @@ RSpec.describe Specwrk::Web::Endpoints do
         end
       end
 
+      context "completed queue is empty" do
+        let(:body) { JSON.generate([]) }
+
+        before do
+          processing_queue.clear
+          pending_queue.clear
+        end
+
+        it "doesn't try to dump the completed queue" do
+          expect(completed_queue).not_to receive(:dump_and_write)
+
+          subject
+        end
+      end
+
       context "pending and processing queues are empty" do
         before do
           processing_queue.delete(2)


### PR DESCRIPTION
Fixed in f50206897420f4717efe99da9806931cc4d2e546 but tested here. Fixes #43