### PR TITLE
Better GHA Examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,8 @@ on:
   pull_request:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
-    name: specwrk
     strategy:
       matrix:
         ruby:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: specwrk
 
 on:
   push:
@@ -10,11 +10,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    name: specwrk
     strategy:
       matrix:
         ruby:
-          - "3.4.2"
+          - "3.4.4"
           - "3.3.0"
           - "3.2.0"
           - "3.1.0"
@@ -26,14 +26,9 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Run the default task
-        run: bundle exec rake
 
-      - name: Run tests via specwrk start
-        run: bundle exec specwrk start --count 2 spec/
-
-      - name: Run tests via specwrk and individual commands
-        run: |
-          bundle exec specwrk serve --single-run 2>&1 &
-          bundle exec specwrk seed spec
-          bundle exec specwrk work --count 2
+      - name: Standard
+        run: bundle exec rake standard
+      
+      - name: RSpec
+        run: bundle exec rspec

--- a/.github/workflows/specwrk-multi-node.yml
+++ b/.github/workflows/specwrk-multi-node.yml
@@ -1,0 +1,65 @@
+name: specwrk-multi-node
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.4
+          bundler-cache: true
+
+      ## SPECWRK STEP ##
+      - name: Seed examples to specwrk server
+        env:
+          SPECWRK_RUN: ${{ github.run_id }}-${{ github.run_attempt }}
+          SPECWRK_SRV_KEY: ${{ secrets.SPECWRK_SRV_KEY }}
+          SPECWRK_SRV_URI: ${{ secrets.SPECWRK_SRV_URI }}
+        run: bundle exec specwrk seed spec/
+      ## /SPECWRK STEP ##
+    
+  specwrk-multi-node:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs: [prepare]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # [n] - where the n is a number of parallel jobs you want to run your tests on.
+        # Use a higher number if you have slow tests to split them between more parallel jobs.
+        # Remember to update the value of the `ci_node_index` below to (0..n-1).
+        ci_node_total: [2]
+        # Indexes for parallel jobs (starting from zero).
+        # E.g. use [0, 1] for 2 parallel jobs, [0, 1, 2] for 3 parallel jobs, etc.
+        ci_node_index: [0, 1]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.4
+          bundler-cache: true
+
+      ## SPECWRK STEP ##
+      - name: Run tests via specwrk work
+        env:
+          SPECWRK_RUN: ${{ github.run_id }}-${{ github.run_attempt }}
+          SPECWRK_SRV_KEY: ${{ secrets.SPECWRK_SRV_KEY }}
+          SPECWRK_SRV_URI: ${{ secrets.SPECWRK_SRV_URI }}
+        run: bundle exec specwrk work --count 2
+      ## SPECWRK STEP ##

--- a/.github/workflows/specwrk-single-node.yml
+++ b/.github/workflows/specwrk-single-node.yml
@@ -1,0 +1,35 @@
+name: specwrk-single-node
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: specwrk-single-node
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore specwrk
+        uses: actions/cache@v4
+        with:
+          path: |
+            .specwrk/report.json
+          key: specwrk-${{ hashFiles('spec/**/*_spec.rb') }}
+          restore-keys: |
+            specwrk-${{ hashFiles('spec/**/*_spec.rb') }}
+            specwrk-
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.4
+          bundler-cache: true
+
+      - name: Run tests via specwrk start
+        run: bundle exec specwrk start --count 2 spec/

--- a/.github/workflows/specwrk-single-node.yml
+++ b/.github/workflows/specwrk-single-node.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      ## SPECWRK STEP ##
       - name: Restore specwrk
         uses: actions/cache@v4
         with:
@@ -23,6 +24,7 @@ jobs:
           restore-keys: |
             specwrk-${{ hashFiles('spec/**/*_spec.rb') }}
             specwrk-
+      ## /SPECWRK STEP ##
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -30,5 +32,7 @@ jobs:
           ruby-version: 3.4.4
           bundler-cache: true
 
+      ## SPECWRK STEP ##
       - name: Run tests via specwrk start
         run: bundle exec specwrk start --count 2 spec/
+      ## /SPECWRK STEP ##

--- a/.github/workflows/specwrk-single-node.yml
+++ b/.github/workflows/specwrk-single-node.yml
@@ -8,9 +8,8 @@ on:
   pull_request:
 
 jobs:
-  build:
+  specwrk-single-node:
     runs-on: ubuntu-latest
-    name: specwrk-single-node
 
     steps:
       - uses: actions/checkout@v4

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,5 +14,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  # config.before(:each) { sleep 1 }
+  if ENV["TEST_ENV_NUMBER"]
+    config.before(:each) { sleep 0.25 }
+  end
 end

--- a/spec/specwrk/worker_spec.rb
+++ b/spec/specwrk/worker_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Specwrk::Worker do
         expect(instance).to receive(:warn)
           .with(a_string_including("refusing connections"))
 
-        expect(subject).to eq(3)
+        expect(subject).to eq(1)
       end
     end
 

--- a/spec/specwrk/worker_spec.rb
+++ b/spec/specwrk/worker_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Specwrk::Worker do
         expect(instance).to receive(:warn)
           .with(a_string_including("refusing connections"))
 
-        expect(subject).to eq(1)
+        expect(subject).to eq(3)
       end
     end
 


### PR DESCRIPTION
- traditional `main.yml` which runs `rake standard` and `rspec`
- `specwrk-single-node.yml` which uses `specwrk start --count 2` on a single node (2 total worker processes)
- `specwrk-multi-node.yml` which uses `specwrk seed` on a single node and `specwrk work --count 2` on 2 nodes (4 total worker processes)