### PR TITLE
Better handling of seed failing

### DIFF
--- a/lib/specwrk/cli.rb
+++ b/lib/specwrk/cli.rb
@@ -122,8 +122,10 @@ module Specwrk
         Client.new.seed(examples)
       rescue Errno::ECONNREFUSED
         puts "Server at #{ENV.fetch("SPECWRK_SRV_URI", "http://localhost:5138")} is refusing connections, exiting...#{ENV["SPECWRK_FLUSH_DELIMINATOR"]}"
+        exit 1
       rescue Errno::ECONNRESET
         puts "Server at #{ENV.fetch("SPECWRK_SRV_URI", "http://localhost:5138")} stopped responding to connections, exiting...#{ENV["SPECWRK_FLUSH_DELIMINATOR"]}"
+        exit 1
       end
     end
 
@@ -213,7 +215,10 @@ module Specwrk
           status "Samples seeded ✓"
         end
 
-        Specwrk.wait_for_pids_exit([seed_pid])
+        if Specwrk.wait_for_pids_exit([seed_pid]).value?(1)
+          Process.kill("INT", web_pid)
+          exit(1)
+        end
 
         return if Specwrk.force_quit
         status "Starting #{worker_count} workers..."

--- a/lib/specwrk/client.rb
+++ b/lib/specwrk/client.rb
@@ -102,13 +102,13 @@ module Specwrk
     def complete_examples(examples)
       response = post "/complete", body: examples.to_json
 
-      (response.code == "200") ? true : UnhandledResponseError.new("#{response.code}: #{response.body}")
+      (response.code == "200") ? true : raise(UnhandledResponseError.new("#{response.code}: #{response.body}"))
     end
 
     def seed(examples)
       response = post "/seed", body: examples.to_json
 
-      (response.code == "200") ? true : UnhandledResponseError.new("#{response.code}: #{response.body}")
+      (response.code == "200") ? true : raise(UnhandledResponseError.new("#{response.code}: #{response.body}"))
     end
 
     private

--- a/spec/specwrk/client_spec.rb
+++ b/spec/specwrk/client_spec.rb
@@ -224,9 +224,8 @@ RSpec.describe Specwrk::Client do
         stub_request(:post, "#{base_uri}/complete").to_return(status: 500, body: "boom")
       end
 
-      it "returns an UnhandledResponseError instance" do
-        expect(subject).to be_a(Specwrk::UnhandledResponseError)
-        expect(subject.message).to include("500: boom")
+      it "raises an UnhandledResponseError" do
+        expect { subject }.to raise_error(Specwrk::UnhandledResponseError, /500: boom/)
       end
     end
   end
@@ -250,9 +249,8 @@ RSpec.describe Specwrk::Client do
         stub_request(:post, "#{base_uri}/seed").to_return(status: 500, body: "boom")
       end
 
-      it "returns an UnhandledResponseError instance" do
-        expect(subject).to be_a(Specwrk::UnhandledResponseError)
-        expect(subject.message).to include("500: boom")
+      it "raises an UnhandledResponseError" do
+        expect { subject }.to raise_error(Specwrk::UnhandledResponseError, /500: boom/)
       end
     end
   end


### PR DESCRIPTION
- Exits 1 if the process exits non-zero in `start`; INTs server
- Exit 1 for handled errors in `seed`
- Raises errors instead of returning them from client 😵

Fixes #51