### PR TITLE
Reap queues based on staleness of workers

### DIFF
--- a/lib/specwrk/web.rb
+++ b/lib/specwrk/web.rb
@@ -12,5 +12,11 @@ module Specwrk
     def self.clear_queues
       [PENDING_QUEUES, PROCESSING_QUEUES, COMPLETED_QUEUES, WORKERS].each(&:clear)
     end
+
+    def self.clear_run_queues(run)
+      [PENDING_QUEUES, PROCESSING_QUEUES, COMPLETED_QUEUES, WORKERS].each do |queue|
+        queue.delete(run)
+      end
+    end
   end
 end

--- a/lib/specwrk/web/app.rb
+++ b/lib/specwrk/web/app.rb
@@ -13,6 +13,7 @@ rescue LoadError
   require "rack/handler/webrick"
 end
 
+require "specwrk/web"
 require "specwrk/web/logger"
 require "specwrk/web/auth"
 require "specwrk/web/endpoints"
@@ -20,6 +21,8 @@ require "specwrk/web/endpoints"
 module Specwrk
   class Web
     class App
+      REAP_INTERVAL = 330 # HTTP connection timeout + some buffer
+
       class << self
         def run!
           Process.setproctitle "specwrk-server"
@@ -73,6 +76,10 @@ module Specwrk
         end
       end
 
+      def initialize
+        @reaper_thread = Thread.new { reaper } unless ENV["SPECWRK_SRV_SINGLE_RUN"]
+      end
+
       def call(env)
         env[:request] ||= Rack::Request.new(env)
 
@@ -99,6 +106,26 @@ module Specwrk
           Endpoints::Shutdown
         else
           Endpoints::NotFound
+        end
+      end
+
+      def reaper
+        until Specwrk.force_quit
+          sleep REAP_INTERVAL
+
+          reap
+        end
+      end
+
+      def reap
+        Web::WORKERS.each do |run, workers|
+          most_recent_last_seen_at = workers.map { |id, worker| worker[:last_seen_at] }.max
+          next unless most_recent_last_seen_at
+
+          # Don't consider runs which aren't at least REAP_INTERVAL sec stale
+          if most_recent_last_seen_at < Time.now - REAP_INTERVAL
+            Web.clear_run_queues(run)
+          end
         end
       end
     end

--- a/lib/specwrk/web/endpoints.rb
+++ b/lib/specwrk/web/endpoints.rb
@@ -146,25 +146,7 @@ module Specwrk
 
       class Shutdown < Base
         def response
-          if ENV["SPECWRK_SRV_SINGLE_RUN"]
-            interupt!
-          elsif processing_queue.length.positive?
-            # Push any processing jobs back into the pending queue
-            processing_queue.synchronize do |processing_queue_hash|
-              pending_queue.synchronize do |pending_queue_hash|
-                processing_queue_hash.each do |id, example|
-                  pending_queue_hash[id] = example
-                  processing_queue_hash.delete(id)
-                end
-              end
-            end
-
-          elsif processing_queue.length.zero? && pending_queue.length.zero?
-            # All done, we can clear the completed queue
-            completed_queue.clear
-          end
-
-          # TODO: clear any zombie queues
+          interupt! if ENV["SPECWRK_SRV_SINGLE_RUN"]
 
           [200, {"Content-Type" => "text/plain"}, ["✌️"]]
         end

--- a/spec/specwrk/web/app_spec.rb
+++ b/spec/specwrk/web/app_spec.rb
@@ -5,6 +5,9 @@ require "tempfile"
 require "specwrk/web/app"
 
 RSpec.describe Specwrk::Web::App do
+  # make sure the reaper thread doesn't start for the test
+  before { stub_const("ENV", {"SPECWRK_SRV_SINGLE_RUN" => "1"}) }
+
   describe ".run!" do
     subject { described_class.run! }
 
@@ -145,6 +148,111 @@ RSpec.describe Specwrk::Web::App do
       before { stub_endpoint(Specwrk::Web::Endpoints::NotFound, 104) }
 
       it { is_expected.to eq 104 }
+    end
+  end
+
+  describe "#reaper" do
+    let(:instance) { described_class.new }
+
+    it "loops calling #reap until Specwrk.force_quit" do
+      stub_const("ENV", {"SPECWRK_SRV_SINGLE_RUN" => "1"}) # make sure the thread doesn't start for the test
+
+      count = 0
+
+      expect(Specwrk).to receive(:force_quit).exactly(6).times do
+        count += 1
+        count == 6
+      end
+
+      expect(instance).to receive(:sleep)
+        .with(330)
+        .exactly(5).times
+
+      expect(instance).to receive(:reap)
+        .exactly(5).times
+
+      instance.reaper
+    end
+  end
+
+  describe "#reap" do
+    subject { instance.reap }
+
+    let(:instance) { described_class.new }
+    let(:now) { Time.now }
+
+    before do
+      allow(Time).to receive(:now)
+        .and_return(now)
+
+      Specwrk::Web.clear_queues
+    end
+
+    context "no runs yet" do
+      it "does nothing and raises no error" do
+        expect(Specwrk::Web).not_to receive(:clear_run_queues)
+
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "no most_recent_last_seen_at" do
+      before do
+        # All workers have nil last_seen_at
+        Specwrk::Web::WORKERS[:run1] = {
+          worker1: {last_seen_at: nil},
+          worker2: {last_seen_at: nil}
+        }
+      end
+
+      it "does not clear any run queues" do
+        expect(Specwrk::Web).not_to receive(:clear_run_queues)
+
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "most_recent_last_seen_at not > 330 sec old" do
+      before do
+        Specwrk::Web::WORKERS[:run1] = {
+          worker1: {last_seen_at: now - 300},
+          worker2: {last_seen_at: now - 200}
+        }
+      end
+
+      it "does not clear any run queues when not stale enough" do
+        expect(Specwrk::Web).not_to receive(:clear_run_queues)
+
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context "most recent last_seen_at > 330 sec old" do
+      before do
+        Specwrk::Web::WORKERS[:run1] = {
+          worker1: {last_seen_at: now - 400},
+          worker2: {last_seen_at: now - 350}
+        }
+        Specwrk::Web::WORKERS[:run2] = {
+          worker1: {last_seen_at: now - 500}
+        }
+        Specwrk::Web::WORKERS[:run3] = {
+          worker1: {last_seen_at: now - 300}
+        }
+      end
+
+      it "clears the stale run queues for each stale run" do
+        expect(Specwrk::Web).to receive(:clear_run_queues)
+          .with(:run1)
+
+        expect(Specwrk::Web).to receive(:clear_run_queues)
+          .with(:run2)
+
+        expect(Specwrk::Web).not_to receive(:clear_run_queues)
+          .with(:run3)
+
+        expect { subject }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
Adds a reaper thread that cleans up queues which haven't been seen in an age.

- removes re-queue logic from shutdown endpoint that didn't do anything.

Fixes #52