### PR TITLE
Switch from puma to pitchfork

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,11 +1,6 @@
 FROM ruby:3.4-alpine
 
-RUN apk add --no-cache \
-      build-base \
-      ruby-dev \
-      linux-headers \
-      zlib-dev \
-      libffi-dev
+RUN apk add --no-cache build-base 
 
 WORKDIR /app
 
@@ -13,14 +8,15 @@ RUN mkdir .specwrk/
 
 ARG SPECWRK_SRV_PORT=5138
 ARG SPECWRK_VERSION=latest
-ARG GEMFILE=specwrk-$SPECWRK_VERSION.gem
+ARG GEM_FILE=specwrk-$SPECWRK_VERSION.gem
 
-COPY $GEMFILE ./
-RUN gem install ./$GEMFILE --no-document
-RUN rm ./$GEMFILE
+COPY $GEM_FILE ./
+RUN gem install ./$GEM_FILE --no-document
+RUN rm ./$GEM_FILE
 
-RUN gem install puma thruster
+RUN gem install pitchfork thruster
 COPY config.ru ./
+COPY docker/pitchfork.conf ./
 
 COPY docker/entrypoint.server.sh /usr/local/bin/entrypoint
 RUN chmod +x /usr/local/bin/entrypoint

--- a/docker/entrypoint.server.sh
+++ b/docker/entrypoint.server.sh
@@ -2,6 +2,6 @@
 
 export THRUSTER_HTTP_PORT=${PORT:-5138}
 export THRUSTER_TARGET_PORT=3000
-export THRUSTER_HTTP_IDLE_TIMEOUT=${IDLE_TIMEOUT:-305}
+export THRUSTER_HTTP_IDLE_TIMEOUT=${IDLE_TIMEOUT:-300}
 
-exec thrust puma --workers 0 --bind tcp://127.0.0.1:3000 --threads ${PUMA_THREADS:-1}
+exec thrust pitchfork -c pitchfork.conf

--- a/docker/pitchfork.conf
+++ b/docker/pitchfork.conf
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+worker_processes 1
+listen "localhost:3000", backlog: 2048
+timeout 301

--- a/lib/specwrk/web/auth.rb
+++ b/lib/specwrk/web/auth.rb
@@ -28,7 +28,7 @@ module Specwrk
       private
 
       def unauthorized
-        [401, {"Content-Type" => "application/json"}, ["Unauthorized"]]
+        [401, {"content-type" => "application/json"}, ["Unauthorized"]]
       end
     end
   end

--- a/lib/specwrk/web/endpoints.rb
+++ b/lib/specwrk/web/endpoints.rb
@@ -22,11 +22,11 @@ module Specwrk
         attr_reader :request
 
         def not_found
-          [404, {"Content-Type" => "text/plain"}, ["This is not the path you're looking for, 'ol chap..."]]
+          [404, {"content-type" => "text/plain"}, ["This is not the path you're looking for, 'ol chap..."]]
         end
 
         def ok
-          [200, {"Content-Type" => "text/plain"}, ["OK, 'ol chap"]]
+          [200, {"content-type" => "text/plain"}, ["OK, 'ol chap"]]
         end
 
         def payload
@@ -125,11 +125,11 @@ module Specwrk
           end
 
           if @examples.length.positive?
-            [200, {"Content-Type" => "application/json"}, [JSON.generate(@examples)]]
+            [200, {"content-type" => "application/json"}, [JSON.generate(@examples)]]
           elsif pending_queue.length.zero? && processing_queue.length.zero? && completed_queue.length.zero?
-            [204, {"Content-Type" => "text/plain"}, ["Waiting for sample to be seeded."]]
+            [204, {"content-type" => "text/plain"}, ["Waiting for sample to be seeded."]]
           elsif completed_queue.length.positive? && processing_queue.length.zero?
-            [410, {"Content-Type" => "text/plain"}, ["That's a good lad. Run along now and go home."]]
+            [410, {"content-type" => "text/plain"}, ["That's a good lad. Run along now and go home."]]
           else
             not_found
           end
@@ -139,9 +139,9 @@ module Specwrk
       class Report < Base
         def response
           if data
-            [200, {"Content-Type" => "application/json"}, [data]]
+            [200, {"content-type" => "application/json"}, [data]]
           else
-            [404, {"Content-Type" => "text/plain"}, ["Unable to report on run #{run_id}; no file matching #{"*-report-#{run_id}.json"}"]]
+            [404, {"content-type" => "text/plain"}, ["Unable to report on run #{run_id}; no file matching #{"*-report-#{run_id}.json"}"]]
           end
         end
 
@@ -168,7 +168,7 @@ module Specwrk
         def response
           interupt! if ENV["SPECWRK_SRV_SINGLE_RUN"]
 
-          [200, {"Content-Type" => "text/plain"}, ["✌️"]]
+          [200, {"content-type" => "text/plain"}, ["✌️"]]
         end
 
         def interupt!

--- a/spec/specwrk/web/endpoints_spec.rb
+++ b/spec/specwrk/web/endpoints_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Specwrk::Web::Endpoints do
   let(:worker_id) { "foobar-0" }
   let(:response) { instance.response }
   let(:instance) { described_class.new(request) }
-  let(:ok) { [200, {"Content-Type" => "text/plain"}, ["OK, 'ol chap"]] }
+  let(:ok) { [200, {"content-type" => "text/plain"}, ["OK, 'ol chap"]] }
 
   let(:pending_queue) { Specwrk::Web::PENDING_QUEUES[run_id] }
   let(:processing_queue) { Specwrk::Web::PROCESSING_QUEUES[run_id] }
@@ -148,25 +148,25 @@ RSpec.describe Specwrk::Web::Endpoints do
     context "successfully pops an item off the queue" do
       before { pending_queue.merge!(1 => {id: 1, expected_run_time: 0}) }
 
-      it { is_expected.to eq([200, {"Content-Type" => "application/json"}, [JSON.generate([{id: 1, expected_run_time: 0}])]]) }
+      it { is_expected.to eq([200, {"content-type" => "application/json"}, [JSON.generate([{id: 1, expected_run_time: 0}])]]) }
       it { expect { subject }.to change(pending_queue, :length).from(1).to(0) }
       it { expect { subject }.to change(processing_queue, :length).from(0).to(1) }
     end
 
     context "no items in any queue" do
-      it { is_expected.to eq([204, {"Content-Type" => "text/plain"}, ["Waiting for sample to be seeded."]]) }
+      it { is_expected.to eq([204, {"content-type" => "text/plain"}, ["Waiting for sample to be seeded."]]) }
     end
 
     context "no items in the processing queue, but completed queue has items" do
       before { completed_queue.merge!(2 => {id: 2, expected_run_time: 0}) }
 
-      it { is_expected.to eq([410, {"Content-Type" => "text/plain"}, ["That's a good lad. Run along now and go home."]]) }
+      it { is_expected.to eq([410, {"content-type" => "text/plain"}, ["That's a good lad. Run along now and go home."]]) }
     end
 
     context "no items in the pending queue, but something in the processing queue" do
       before { processing_queue.merge!(2 => {id: 2, expected_run_time: 0}) }
 
-      it { is_expected.to eq([404, {"Content-Type" => "text/plain"}, ["This is not the path you're looking for, 'ol chap..."]]) }
+      it { is_expected.to eq([404, {"content-type" => "text/plain"}, ["This is not the path you're looking for, 'ol chap..."]]) }
     end
   end
 
@@ -179,7 +179,7 @@ RSpec.describe Specwrk::Web::Endpoints do
     end
 
     context "run report file does not exist" do
-      it { is_expected.to eq([404, {"Content-Type" => "text/plain"}, ["Unable to report on run #{run_id}; no file matching *-report-main.json"]]) }
+      it { is_expected.to eq([404, {"content-type" => "text/plain"}, ["Unable to report on run #{run_id}; no file matching *-report-main.json"]]) }
     end
 
     context "run report file does exist" do
@@ -193,7 +193,7 @@ RSpec.describe Specwrk::Web::Endpoints do
         FileUtils.rm(most_recent_run_report_file)
       end
 
-      it { is_expected.to eq([200, {"Content-Type" => "application/json"}, [file_content]]) }
+      it { is_expected.to eq([200, {"content-type" => "application/json"}, [file_content]]) }
     end
   end
 end


### PR DESCRIPTION
Switches from single-worker & single-thread puma to single worker & no-threads pitchfork. Since queues live in memory and the server is CPU bound, we probably don't want to mess with threads.