### PR TITLE
Only exit 1 when no examples are processed and the run is not completed

### DIFF
--- a/lib/specwrk/worker.rb
+++ b/lib/specwrk/worker.rb
@@ -19,6 +19,7 @@ module Specwrk
       @running = true
       @client = Client.new
       @executor = Executor.new
+      @all_examples_completed = false
       @seed_waits = ENV.fetch("SPECWRK_SEED_WAITS", "10").to_i
       @heartbeat_thread ||= Thread.new do
         thump
@@ -33,6 +34,7 @@ module Specwrk
 
         execute
       rescue CompletedAllExamplesError
+        @all_examples_completed = true
         break
       rescue NoMoreExamplesError
         # Wait for the other processes (workers) on the same host to finish
@@ -102,7 +104,7 @@ module Specwrk
     attr_reader :running, :client, :executor
 
     def status
-      return 1 unless executor.example_processed
+      return 1 if !executor.example_processed && !@all_examples_completed
       return 1 if executor.failure
       return 1 if Specwrk.force_quit
 

--- a/spec/specwrk/worker_spec.rb
+++ b/spec/specwrk/worker_spec.rb
@@ -75,9 +75,24 @@ RSpec.describe Specwrk::Worker do
 
       before { allow(Specwrk::Client).to receive(:wait_for_server!) }
 
-      it "returns 1 when no examples were processed" do
+      it "returns 0 when no examples were processed, but server signals all examples completed" do
         expect(instance).to receive(:execute)
           .and_raise(Specwrk::CompletedAllExamplesError)
+
+        expect(subject).to eq(0)
+      end
+
+      it "returns 1 when no examples were processed, but server did not signal all examples completed" do
+        expect(instance).to receive(:sleep)
+          .with(1)
+          .exactly(10).times
+
+        expect(instance).to receive(:warn)
+          .exactly(11).times
+
+        expect(instance).to receive(:execute)
+          .and_raise(Specwrk::WaitingForSeedError)
+          .exactly(11).times
 
         expect(subject).to eq(1)
       end


### PR DESCRIPTION
Fixes #81 by tracking if the reason for the loop break was the server signaling `CompletedAllExamplesError` which only happens when the complete queue is not empty.