### PR TITLE
If RSpec is defined, set wants_to_quit to true on INT

### DIFF
--- a/exe/specwrk
+++ b/exe/specwrk
@@ -9,6 +9,7 @@ trap("INT") do
 
     Specwrk.force_quit = true
   elsif Specwrk.starting_pid != Process.pid
+    RSpec.world.wants_to_quit = true if defined?(RSpec)
     exit(1) if Specwrk.force_quit
     Specwrk.force_quit = true
   end


### PR DESCRIPTION
This stops internal rspec execution faster