### PR TITLE
Configurable store adapaters

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,15 @@ Options:
   --key=VALUE, -k VALUE             # Authentication key clients must use for access. Overrides SPECWRK_SRV_KEY, default: ""
   --run=VALUE, -r VALUE             # The run identifier for this job execution. Overrides SPECWRK_RUN, default: "main"
   --timeout=VALUE, -t VALUE         # The amount of time to wait for the server to respond. Overrides SPECWRK_TIMEOUT, default: "5"
-  --id=VALUE                        # The identifier for this worker. Default specwrk-worker(-COUNT_INDEX), default: "specwrk-worker"
+  --id=VALUE                        # The identifier for this worker. Overrides SPECWRK_ID. If none provided one in the format of specwrk-worker-8_RAND_CHARS-COUNT_INDEX will be used
   --count=VALUE, -c VALUE           # The number of worker processes you want to start, default: 1
   --output=VALUE, -o VALUE          # Directory where worker output is stored. Overrides SPECWRK_OUT, default: ".specwrk/"
   --seed-waits=VALUE, -w VALUE      # Number of times the worker will wait for examples to be seeded to the server. 1sec between attempts. Overrides SPECWRK_SEED_WAITS, default: "10"
   --port=VALUE, -p VALUE            # Server port. Overrides SPECWRK_SRV_PORT, default: "5138"
   --bind=VALUE, -b VALUE            # Server bind address. Overrides SPECWRK_SRV_BIND, default: "127.0.0.1"
+  --store-uri=VALUE                 # Directory where server state is stored. Required for multi-node or multi-process servers.
   --group-by=VALUE                  # How examples will be grouped for workers; fallback to file if no timings are found. Overrides SPECWERK_SRV_GROUP_BY: (file/timings), default: "timings"
-  --[no-]verbose                    # Run in verbose mode. Default false., default: false
+  --[no-]verbose                    # Run in verbose mode, default: false
   --help, -h                        # Print this help
 ```
 
@@ -80,10 +81,11 @@ Options:
   --port=VALUE, -p VALUE            # Server port. Overrides SPECWRK_SRV_PORT, default: "5138"
   --bind=VALUE, -b VALUE            # Server bind address. Overrides SPECWRK_SRV_BIND, default: "127.0.0.1"
   --key=VALUE, -k VALUE             # Authentication key clients must use for access. Overrides SPECWRK_SRV_KEY, default: ""
-  --output=VALUE, -o VALUE          # Directory where worker output is stored. Overrides SPECWRK_OUT, default: ".specwrk/"
+  --output=VALUE, -o VALUE          # Directory where worker or server output is stored. Overrides SPECWRK_OUT, default: ".specwrk/"
+  --store-uri=VALUE                 # Directory where server state is stored. Required for multi-node or multi-process servers.
   --group-by=VALUE                  # How examples will be grouped for workers; fallback to file if no timings are found. Overrides SPECWERK_SRV_GROUP_BY: (file/timings), default: "timings"
-  --[no-]verbose                    # Run in verbose mode. Default false., default: false
-  --[no-]single-run                 # Act on shutdown requests from clients. Default: false., default: false
+  --[no-]verbose                    # Run in verbose mode, default: false
+  --[no-]single-run                 # Act on shutdown requests from clients, default: false
   --help, -h                        # Print this help
 ```
 
@@ -196,7 +198,7 @@ Start a persistent Queue Server given one of the following methods
 
 ### Configuring your Queue Server
 - Secure your server with a key either with the `SPECWRK_SRV_KEY` environment variable or `--key` CLI option
-- Configure the server output to be a persisted volume so your timings survive between restarts with  the `SPECWRK_OUT` environment variable or `--out` CLI option 
+- Configure the server output to be a persisted volume so your timings survive between system restarts with the `SPECWRK_SRV_STORE_URI` environment variable or `--store-uri` CLI option. By default, `memory:///` will be used for the run's data stores (so run data will no survive server restarts) while `file://#{Dir.tmpdir}` will be used for run timings. Pass `--store-uri file:///whatever/absolute/path` to store all data on disk (required for multiple server processes).
 
 See [specwrk serve --help](#specwrk-serve) for all possible configuration options.
 

--- a/lib/specwrk/cli.rb
+++ b/lib/specwrk/cli.rb
@@ -74,13 +74,15 @@ module Specwrk
         base.unique_option :port, type: :integer, default: ENV.fetch("SPECWRK_SRV_PORT", "5138"), aliases: ["-p"], desc: "Server port. Overrides SPECWRK_SRV_PORT"
         base.unique_option :bind, type: :string, default: ENV.fetch("SPECWRK_SRV_BIND", "127.0.0.1"), aliases: ["-b"], desc: "Server bind address. Overrides SPECWRK_SRV_BIND"
         base.unique_option :key, type: :string, aliases: ["-k"], default: ENV.fetch("SPECWRK_SRV_KEY", ""), desc: "Authentication key clients must use for access. Overrides SPECWRK_SRV_KEY"
-        base.unique_option :output, type: :string, default: ENV.fetch("SPECWRK_OUT", ".specwrk/"), aliases: ["-o"], desc: "Directory where worker output is stored. Overrides SPECWRK_OUT"
+        base.unique_option :output, type: :string, default: ENV.fetch("SPECWRK_OUT", ".specwrk/"), aliases: ["-o"], desc: "Directory where worker or server output is stored. Overrides SPECWRK_OUT"
+        base.unique_option :store_uri, type: :string, desc: "Directory where server state is stored. Required for multi-node or multi-process servers."
         base.unique_option :group_by, values: %w[file timings], default: ENV.fetch("SPECWERK_SRV_GROUP_BY", "timings"), desc: "How examples will be grouped for workers; fallback to file if no timings are found. Overrides SPECWERK_SRV_GROUP_BY"
-        base.unique_option :verbose, type: :boolean, default: false, desc: "Run in verbose mode. Default false."
+        base.unique_option :verbose, type: :boolean, default: false, desc: "Run in verbose mode"
       end
 
-      on_setup do |port:, bind:, output:, key:, group_by:, verbose:, **|
+      on_setup do |port:, bind:, output:, key:, group_by:, verbose:, **opts|
         ENV["SPECWRK_OUT"] = Pathname.new(output).expand_path(Dir.pwd).to_s
+        ENV["SPECWRK_SRV_STORE_URI"] = opts[:store_uri] if opts.key? :store_uri
         ENV["SPECWRK_SRV_VERBOSE"] = "1" if verbose
 
         ENV["SPECWRK_SRV_PORT"] = port
@@ -158,7 +160,7 @@ module Specwrk
       include Servable
 
       desc "Start a queue server"
-      option :single_run, type: :boolean, default: false, desc: "Act on shutdown requests from clients. Default: false."
+      option :single_run, type: :boolean, default: false, desc: "Act on shutdown requests from clients"
 
       def call(single_run:, **args)
         ENV["SPECWRK_SRV_SINGLE_RUN"] = "1" if single_run

--- a/lib/specwrk/store/base_adapter.rb
+++ b/lib/specwrk/store/base_adapter.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "uri"
+
+require "specwrk/store"
+
+module Specwrk
+  class Store
+    class BaseAdapter
+      def initialize(uri, scope)
+        @uri = uri
+        @scope = scope
+      end
+
+      def [](key)
+        raise "Not implemented"
+      end
+
+      def []=(key, value)
+        raise "Not implemented"
+      end
+
+      def keys
+        raise "Not implemented"
+      end
+
+      def clear
+        raise "Not implemented"
+      end
+
+      def delete(*keys)
+        raise "Not implemented"
+      end
+
+      def merge!(h2)
+        raise "Not implemented"
+      end
+
+      def multi_read(*read_keys)
+        raise "Not implemented"
+      end
+
+      def multi_write(hash)
+        raise "Not implemented"
+      end
+
+      def empty?
+        raise "Not implemented"
+      end
+
+      private
+
+      attr_reader :uri, :scope
+    end
+  end
+end

--- a/lib/specwrk/store/memory_adapter.rb
+++ b/lib/specwrk/store/memory_adapter.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "specwrk/store/base_adapter"
+
+module Specwrk
+  class Store
+    class MemoryAdapter < BaseAdapter
+      @@stores = Hash.new { |hash, key| hash[key] = {} }
+
+      class << self
+        def clear
+          @@stores.values.each(&:clear)
+        end
+      end
+
+      def [](key)
+        store[key]
+      end
+
+      def []=(key, value)
+        store[key] = value
+      end
+
+      def keys
+        store.keys
+      end
+
+      def clear
+        store.clear
+      end
+
+      def delete(*keys)
+        keys.each { |key| store.delete(key) }
+      end
+
+      def merge!(h2)
+        store.merge!(h2)
+      end
+
+      def multi_read(*read_keys)
+        store.slice(*read_keys)
+      end
+
+      def multi_write(hash)
+        merge!(hash)
+      end
+
+      def empty?
+        store.keys.length.zero?
+      end
+
+      private
+
+      def store
+        @store ||= @@stores[scope]
+      end
+    end
+  end
+end

--- a/spec/specwrk/store/file_adapter_spec.rb
+++ b/spec/specwrk/store/file_adapter_spec.rb
@@ -5,8 +5,11 @@ require "tmpdir"
 require "specwrk/store/file_adapter"
 
 RSpec.describe Specwrk::Store::FileAdapter do
-  let(:path) { File.join(Dir.tmpdir, SecureRandom.uuid).tap { |path| FileUtils.mkdir_p(path) } }
-  let(:instance) { described_class.new(path) }
+  let(:path) { File.join(uri.path, scope).tap { |path| FileUtils.mkdir_p(path) } }
+  let(:uri) { URI("file://#{Dir.tmpdir}") }
+  let(:scope) { SecureRandom.uuid }
+
+  let(:instance) { described_class.new(uri, scope) }
 
   def write(key, value)
     @counter ||= -1

--- a/spec/specwrk/store/memory_adapter_spec.rb
+++ b/spec/specwrk/store/memory_adapter_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "specwrk/store/memory_adapter"
+
+RSpec.describe Specwrk::Store::MemoryAdapter do
+  let(:instance) { described_class.new("memory:///foobar", "baz") }
+
+  before { described_class.clear }
+
+  describe "#[]=" do
+    subject { instance["foo"] = "bar" }
+
+    it { expect { subject }.to change { instance["foo"] }.from(nil).to("bar") }
+  end
+
+  describe "#[]" do
+    subject { instance[key] }
+
+    let(:key) { "hello" }
+
+    before { instance[key] = "world" }
+
+    it { is_expected.to eq("world") }
+  end
+
+  describe "#keys" do
+    subject { instance.keys }
+
+    before do
+      instance["a"] = 1
+      instance["b"] = 2
+    end
+
+    it { is_expected.to match_array(%w[a b]) }
+  end
+
+  describe "#clear" do
+    subject { instance.clear }
+
+    before { instance["foo"] = "bar" }
+
+    it { expect { subject }.to change(instance, :empty?).from(false).to(true) }
+  end
+
+  describe "#delete" do
+    subject { instance.delete("one", "two") }
+
+    before do
+      instance["one"] = 1
+      instance["two"] = 2
+    end
+
+    it { expect { subject }.to change { instance.keys }.from(%w[one two]).to([]) }
+  end
+
+  describe "#merge! and #multi_write" do
+    subject { instance.merge!(b: 1, a: 2) }
+
+    it { expect { subject }.to change { instance[:a] }.from(nil).to(2) }
+    it { expect { subject }.to change { instance[:b] }.from(nil).to(1) }
+  end
+
+  describe "#multi_read" do
+    subject { instance.multi_read("a", "c") }
+
+    before { instance.merge!("a" => 1, "b" => 2, "c" => 3) }
+
+    it { is_expected.to eq("a" => 1, "c" => 3) }
+  end
+
+  describe "#empty?" do
+    subject { instance.empty? }
+
+    context "when store is empty" do
+      it { is_expected.to be true }
+    end
+
+    context "when store has data" do
+      before { instance["key"] = "value" }
+
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/spec/specwrk/store_spec.rb
+++ b/spec/specwrk/store_spec.rb
@@ -6,8 +6,10 @@ require "securerandom"
 require "specwrk/store"
 
 RSpec.describe Specwrk::Store do
-  let(:path) { File.join(Dir.mktmpdir, Process.pid.to_s) }
-  let(:instance) { described_class.new(path) }
+  let(:uri_string) { "file://#{Dir.tmpdir}" }
+  let(:scope) { SecureRandom.uuid }
+
+  let(:instance) { described_class.new(uri_string, scope) }
 
   before { instance.clear }
 
@@ -83,8 +85,10 @@ RSpec.describe Specwrk::Store do
 end
 
 RSpec.describe Specwrk::PendingStore do
-  let(:path) { File.join(Dir.mktmpdir, Process.pid.to_s) }
-  let(:instance) { described_class.new(path) }
+  let(:uri_string) { "file://#{Dir.tmpdir}" }
+  let(:scope) { SecureRandom.uuid }
+
+  let(:instance) { described_class.new(uri_string, scope) }
 
   before { instance.clear }
 
@@ -216,8 +220,10 @@ RSpec.describe Specwrk::PendingStore do
 end
 
 RSpec.describe Specwrk::CompletedStore do
-  let(:path) { File.join(Dir.mktmpdir, Process.pid.to_s) }
-  let(:instance) { described_class.new(path) }
+  let(:uri_string) { "file://#{Dir.tmpdir}" }
+  let(:scope) { SecureRandom.uuid }
+
+  let(:instance) { described_class.new(uri_string, scope) }
 
   before { instance.clear }
 

--- a/spec/specwrk/web/endpoints_spec.rb
+++ b/spec/specwrk/web/endpoints_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe Specwrk::Web::Endpoints do
   end
 
   describe "worker endpoints" do
-    let(:metadata) { Specwrk::Store.new(File.join(datastore_path, "metadata")) }
-    let(:run_times) { Specwrk::Store.new File.join(base_path, "run_times") }
-    let(:pending) { Specwrk::PendingStore.new File.join(datastore_path, "pending") }
-    let(:processing) { Specwrk::Store.new File.join(datastore_path, "processing") }
-    let(:completed) { Specwrk::CompletedStore.new File.join(datastore_path, "completed") }
-    let(:worker) { Specwrk::PendingStore.new File.join(datastore_path, "workers", worker_id.to_s) }
+    let(:metadata) { Specwrk::Store.new datastore_uri, "metadata" }
+    let(:run_times) { Specwrk::Store.new base_uri, "run_times" }
+    let(:pending) { Specwrk::PendingStore.new datastore_uri, "pending" }
+    let(:processing) { Specwrk::Store.new datastore_uri, "processing" }
+    let(:completed) { Specwrk::CompletedStore.new datastore_uri, "completed" }
+    let(:worker) { Specwrk::PendingStore.new datastore_uri, File.join("workers", worker_id.to_s) }
 
     let(:existing_run_times_data) { {} }
     let(:existing_pending_data) { {} }
@@ -44,9 +44,11 @@ RSpec.describe Specwrk::Web::Endpoints do
 
     let(:run_id) { "main" }
     let(:worker_id) { :"foobar-0" }
-    let(:datastore_path) { File.join(base_path, run_id).to_s }
-    let(:base_path) { File.join(Dir.tmpdir, Process.pid.to_s).to_s }
-    let(:env_vars) { {"SPECWRK_OUT" => base_path} }
+    let(:datastore_uri) { "file://#{datastore_path}" }
+    let(:datastore_path) { File.join(base_path, run_id) }
+    let(:base_uri) { "file://#{base_path}" }
+    let(:base_path) { File.join(Dir.tmpdir, SecureRandom.uuid) }
+    let(:env_vars) { {"SPECWRK_OUT" => base_path, "SPECWRK_SRV_STORE_URI" => base_uri} }
 
     before do
       stub_const("ENV", env_vars)
@@ -84,8 +86,6 @@ RSpec.describe Specwrk::Web::Endpoints do
       let(:body) { JSON.generate([{id: "a.rb:1", file_path: "a.rb", run_time: 0.1}]) }
 
       context "pending store reset with examples" do
-        let(:env_vars) { {"SPECWRK_OUT" => base_path, "SPECWRK_SRV_SINGLE_SEED_PER_RUN" => nil} }
-
         let(:existing_pending_data) { {"b.rb:2" => {id: "b.rb:2", file_path: "b.rb", expected_run_time: 0.1}} }
 
         it { is_expected.to eq(ok) }


### PR DESCRIPTION
+ Add an in-memory store for `start` commands when not configured 🏎️💨
+ define which store adapter to use, per store
+ default to tmpdir for run times if no store is specified