### PR TITLE
Move store order tracking to the only store class that needs it

### DIFF
--- a/lib/specwrk/store.rb
+++ b/lib/specwrk/store.rb
@@ -98,6 +98,7 @@ module Specwrk
 
   class PendingStore < Store
     RUN_TIME_BUCKET_MAXIMUM_KEY = :____run_time_bucket_maximum
+    ORDER_KEY = :____order
 
     def run_time_bucket_maximum=(val)
       @run_time_bucket_maximum = self[RUN_TIME_BUCKET_MAXIMUM_KEY] = val
@@ -105,6 +106,41 @@ module Specwrk
 
     def run_time_bucket_maximum
       @run_time_bucket_maximum ||= self[RUN_TIME_BUCKET_MAXIMUM_KEY]
+    end
+
+    def order=(val)
+      @order = nil
+
+      self[ORDER_KEY] = if val.nil? || val.length.zero?
+        nil
+      else
+        val
+      end
+    end
+
+    def order
+      @order ||= self[ORDER_KEY] || []
+    end
+
+    def keys
+      return super if order.length.zero?
+
+      order
+    end
+
+    def merge!(hash)
+      super
+      self.order = hash.keys
+    end
+
+    def clear
+      @order = nil
+      super
+    end
+
+    def reload
+      @order = nil
+      super
     end
 
     def shift_bucket
@@ -146,6 +182,7 @@ module Specwrk
       end
 
       delete(*consumed_keys)
+      self.order = order - consumed_keys
       bucket
     end
 
@@ -171,6 +208,7 @@ module Specwrk
       end
 
       delete(*consumed_keys)
+      self.order = order - consumed_keys
       bucket
     end
   end

--- a/spec/specwrk/store_spec.rb
+++ b/spec/specwrk/store_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Specwrk::Store do
 
     before { instance.merge!("foo" => 1, "baz" => 2) }
 
-    it { expect { subject }.to change(instance, :keys).from(["foo", "baz"]).to([]) }
+    it { expect { subject }.to change(instance, :keys).from(match_array(["foo", "baz"])).to([]) }
   end
 
   describe "#inspect" do
@@ -104,6 +104,38 @@ RSpec.describe Specwrk::PendingStore do
     before { instance[described_class::RUN_TIME_BUCKET_MAXIMUM_KEY] = 4 }
 
     it { is_expected.to eq(4) }
+  end
+
+  describe "#order=" do
+    subject { instance.order = value }
+
+    context "sets order array" do
+      let(:value) { [1, 2] }
+
+      it { expect { subject }.to change(instance, :order).from([]).to([1, 2]) }
+    end
+
+    context "order set to empty array nils the stored value" do
+      let(:value) { [] }
+
+      before { instance[described_class::ORDER_KEY] = [2, 1] }
+
+      it { expect { subject }.to change { instance[described_class::ORDER_KEY] }.from([2, 1]).to(nil) }
+    end
+  end
+
+  describe "#order" do
+    subject { instance.order }
+
+    context "order not set" do
+      it { is_expected.to eq([]) }
+    end
+
+    context "order set" do
+      before { instance[described_class::ORDER_KEY] = [1, 2] }
+
+      it { is_expected.to eq([1, 2]) }
+    end
   end
 
   describe "#merge!" do


### PR DESCRIPTION
Keeping track of file store records insertion order is actually quite slow. Moving order tracking to be just another stored key for the pending store makes a lot of sense, resulting in much faster performance for that store and other stores.

It also loosens the requirements of order tracking on other adapters in the future.