### PR TITLE
Add a UUID to the tempfile name when writing to avoid multi-process conflict

### DIFF
--- a/lib/specwrk/store/file_adapter.rb
+++ b/lib/specwrk/store/file_adapter.rb
@@ -126,7 +126,7 @@ module Specwrk
       private
 
       def write(filename, content)
-        tmp_filename = [filename, "tmp"].join(".")
+        tmp_filename = [filename, SecureRandom.uuid, "tmp"].join(".")
 
         File.binwrite(tmp_filename, content)
 


### PR DESCRIPTION
Fixes #107.

Today this only impacts run times which are written without a lock. I considered moving the run times into the `with_lock` block however that will just slow down the throughput; it won't actually prevent anything.

Another option would be to lock the run times in a separate block, however, again, this would probably hurt more in throughput than anything. It'll also be irrelevant for other, future, non-file based adapters.