### PR TITLE
Track worker success metrics

### DIFF
--- a/lib/specwrk/store.rb
+++ b/lib/specwrk/store.rb
@@ -72,7 +72,7 @@ module Specwrk
     end
 
     def to_h
-      adapter.multi_read(*keys).transform_keys!(&:to_sym)
+      multi_read(*keys).transform_keys!(&:to_sym)
     end
 
     def inspect

--- a/lib/specwrk/web/endpoints.rb
+++ b/lib/specwrk/web/endpoints.rb
@@ -33,7 +33,7 @@ module Specwrk
 
           after_lock
 
-          final_response[1]["x-specwrk-status"] = (worker[:failed] || 1).to_s
+          final_response[1]["x-specwrk-status"] = worker_status.to_s
 
           final_response
         end
@@ -102,6 +102,12 @@ module Specwrk
 
         def worker
           @worker ||= Store.new(ENV.fetch("SPECWRK_SRV_STORE_URI", "memory:///"), File.join(run_id, "workers", request.get_header("HTTP_X_SPECWRK_ID").to_s))
+        end
+
+        def worker_status
+          return 0 if worker[:failed].nil? && completed.any? # worker starts after run has completed
+
+          worker[:failed] || 1
         end
 
         def run_id

--- a/lib/specwrk/web/endpoints.rb
+++ b/lib/specwrk/web/endpoints.rb
@@ -33,6 +33,8 @@ module Specwrk
 
           after_lock
 
+          final_response[1]["x-specwrk-status"] = (worker[:failed] || 1).to_s
+
           final_response
         end
 
@@ -238,6 +240,8 @@ module Specwrk
       end
 
       class CompleteAndPop < Popable
+        EXAMPLE_STATUSES = %w[passed failed pending]
+
         def with_response
           completed.merge!(completed_examples)
           processing.delete(*completed_examples.keys)
@@ -251,10 +255,22 @@ module Specwrk
           @completed_data ||= payload.map { |example| [example[:id], example] if processing[example[:id]] }.compact.to_h
         end
 
-        # We don't care about exact values here, just approximate run times are fine
-        # So if we overwrite run times from another process it is nbd
+        def completed_examples_status_counts
+          @completed_examples_status_counts ||= completed_examples.values.map { |example| example[:status] }.tally
+        end
+
         def after_lock
+          # We don't care about exact values here, just approximate run times are fine
+          # So if we overwrite run times from another process it is nbd
           run_times.merge! run_time_data
+
+          # workers are single proces, single-threaded, so safe to do this work without the lock
+          existing_status_counts = worker.multi_read(*EXAMPLE_STATUSES)
+          new_status_counts = EXAMPLE_STATUSES.map do |status|
+            [status, existing_status_counts.fetch(status, 0) + completed_examples_status_counts.fetch(status, 0)]
+          end.to_h
+
+          worker.merge!(new_status_counts)
         end
 
         def run_time_data

--- a/lib/specwrk/worker.rb
+++ b/lib/specwrk/worker.rb
@@ -111,7 +111,6 @@ module Specwrk
 
     def status
       return 1 if !executor.example_processed && !@all_examples_completed
-      return 1 if executor.failure
       return 1 if Specwrk.force_quit
 
       0

--- a/lib/specwrk/worker.rb
+++ b/lib/specwrk/worker.rb
@@ -110,10 +110,10 @@ module Specwrk
     attr_reader :running, :client, :executor
 
     def status
-      return 1 if !@all_examples_completed
+      return 0 if @all_examples_completed && client.worker_status.zero?
       return 1 if Specwrk.force_quit
 
-      0
+      client.worker_status
     end
 
     def warn(msg)

--- a/lib/specwrk/worker.rb
+++ b/lib/specwrk/worker.rb
@@ -110,7 +110,7 @@ module Specwrk
     attr_reader :running, :client, :executor
 
     def status
-      return 1 if !executor.example_processed && !@all_examples_completed
+      return 1 if !@all_examples_completed
       return 1 if Specwrk.force_quit
 
       0

--- a/lib/specwrk/worker/completion_formatter.rb
+++ b/lib/specwrk/worker/completion_formatter.rb
@@ -5,19 +5,14 @@ module Specwrk
     class CompletionFormatter
       RSpec::Core::Formatters.register self, :stop
 
-      attr_reader :examples, :failure
+      attr_reader :examples
 
       def initialize
         @examples = []
-        @failure = false
       end
 
       def stop(group_notification)
         group_notification.notifications.map do |notification|
-          unless failure
-            @failure = notification.example.execution_result.status == :failed
-          end
-
           examples << {
             id: notification.example.id,
             full_description: notification.example.full_description,

--- a/lib/specwrk/worker/executor.rb
+++ b/lib/specwrk/worker/executor.rb
@@ -13,10 +13,6 @@ module Specwrk
     class Executor
       attr_reader :example_processed
 
-      def failure
-        completion_formatter.failure
-      end
-
       def examples
         completion_formatter.examples
       end

--- a/lib/specwrk/worker/executor.rb
+++ b/lib/specwrk/worker/executor.rb
@@ -11,8 +11,6 @@ require "specwrk/worker/null_formatter"
 module Specwrk
   class Worker
     class Executor
-      attr_reader :example_processed
-
       def examples
         completion_formatter.examples
       end
@@ -25,7 +23,6 @@ module Specwrk
         reset!
 
         example_ids = examples.map { |example| example[:id] }
-        @example_processed ||= true unless example_ids.size.zero? # only ever toggle from nil => true
 
         options = RSpec::Core::ConfigurationOptions.new rspec_options + example_ids
         RSpec::Core::Runner.new(options).run($stderr, $stdout)

--- a/spec/specwrk/client_spec.rb
+++ b/spec/specwrk/client_spec.rb
@@ -146,6 +146,28 @@ RSpec.describe Specwrk::Client do
     end
   end
 
+  describe "#worker_status" do
+    subject { client.worker_status }
+
+    let(:client) { described_class.new }
+
+    context "not set" do
+      it { is_expected.to eq(1) }
+    end
+
+    context "server returns a value" do
+      before do
+        stub_request(:get, "#{base_uri}/heartbeat")
+          .with(headers: headers)
+          .to_return(status: 200, headers: {"X-Specwrk-Status" => 42})
+
+        client.heartbeat
+      end
+
+      it { is_expected.to eq(42) }
+    end
+  end
+
   describe "#heartbeat" do
     subject { client.heartbeat }
 

--- a/spec/specwrk/web/endpoints_spec.rb
+++ b/spec/specwrk/web/endpoints_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Specwrk::Web::Endpoints do
   let(:body) { "" }
   let(:response) { instance.response }
   let(:instance) { described_class.new(request) }
-  let(:ok) { [200, {"content-type" => "text/plain"}, ["OK, 'ol chap"]] }
+  let(:ok) { [200, {"content-type" => "text/plain", "x-specwrk-status" => worker_status.to_s}, ["OK, 'ol chap"]] }
+  let(:worker_status) { 1 }
 
   let(:env) do
     {
@@ -133,13 +134,13 @@ RSpec.describe Specwrk::Web::Endpoints do
           {"a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}}
         end
 
-        it { is_expected.to eq([200, {"content-type" => "application/json"}, [JSON.generate([{id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}])]]) }
+        it { is_expected.to eq([200, {"content-type" => "application/json", "x-specwrk-status" => "1"}, [JSON.generate([{id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}])]]) }
         it { expect { subject }.to change { pending.reload.length }.from(1).to(0) }
         it { expect { subject }.to change { processing.reload["a.rb:2"] }.from(nil).to({completion_threshold: instance_of(Integer), expected_run_time: 0.1, file_path: "a.rb", id: "a.rb:2"}) }
       end
 
       context "no items in any queue" do
-        it { is_expected.to eq([204, {"content-type" => "text/plain"}, ["Waiting for sample to be seeded."]]) }
+        it { is_expected.to eq([204, {"content-type" => "text/plain", "x-specwrk-status" => "1"}, ["Waiting for sample to be seeded."]]) }
       end
 
       context "no items in the processing queue, but completed queue has items" do
@@ -147,7 +148,7 @@ RSpec.describe Specwrk::Web::Endpoints do
           {"a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}}
         end
 
-        it { is_expected.to eq([410, {"content-type" => "text/plain"}, ["That's a good lad. Run along now and go home."]]) }
+        it { is_expected.to eq([410, {"content-type" => "text/plain", "x-specwrk-status" => "1"}, ["That's a good lad. Run along now and go home."]]) }
       end
 
       context "no items in the pending queue, but something in the processing queue but none are expired" do
@@ -155,12 +156,12 @@ RSpec.describe Specwrk::Web::Endpoints do
           {"a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}}
         end
 
-        it { is_expected.to eq([404, {"content-type" => "text/plain"}, ["This is not the path you're looking for, 'ol chap..."]]) }
+        it { is_expected.to eq([404, {"content-type" => "text/plain", "x-specwrk-status" => "1"}, ["This is not the path you're looking for, 'ol chap..."]]) }
       end
     end
 
     describe Specwrk::Web::Endpoints::Report do
-      let(:run_report_file_path) { File.join(datastore_path, "#{SecureRandom.uuid}.json").to_s }
+      let(:existing_worker_data) { {failed: 42} }
 
       before do
         completed_dbl = instance_double(Specwrk::CompletedStore)
@@ -172,7 +173,7 @@ RSpec.describe Specwrk::Web::Endpoints do
           .and_return({foo: "bar"})
       end
 
-      it { is_expected.to eq([200, {"content-type" => "application/json"}, [JSON.generate(foo: "bar")]]) }
+      it { is_expected.to eq([200, {"content-type" => "application/json", "x-specwrk-status" => "42"}, [JSON.generate(foo: "bar")]]) }
     end
 
     describe Specwrk::Web::Endpoints::CompleteAndPop do
@@ -180,8 +181,10 @@ RSpec.describe Specwrk::Web::Endpoints do
 
       let(:body) {
         JSON.generate([
-          {id: "a.rb:1", file_path: "a.rb", run_time: 0.1, started_at: Time.now.iso8601, finished_at: Time.now.iso8601},
-          {id: "a.rb:3", file_path: "a.rb", run_time: 0.1, started_at: Time.now.iso8601, finished_at: Time.now.iso8601}
+          {id: "a.rb:1", file_path: "a.rb", run_time: 0.1, started_at: Time.now.iso8601, finished_at: Time.now.iso8601, status: "passed"},
+          {id: "a.rb:3", file_path: "a.rb", run_time: 0.1, started_at: Time.now.iso8601, finished_at: Time.now.iso8601, status: "passed"},
+          {id: "a.rb:4", file_path: "a.rb", run_time: 0.1, started_at: Time.now.iso8601, finished_at: Time.now.iso8601, status: "pending"},
+          {id: "a.rb:5", file_path: "a.rb", run_time: 0.1, started_at: Time.now.iso8601, finished_at: Time.now.iso8601, status: "failed"}
         ])
       }
 
@@ -189,14 +192,19 @@ RSpec.describe Specwrk::Web::Endpoints do
         let(:existing_processing_data) do
           {
             "a.rb:1": {id: "a.rb:1", file_path: "a.rb", expected_run_time: 0.1},
-            "a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}
+            "a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1},
+            "a.rb:4": {id: "a.rb:4", file_path: "a.rb", expected_run_time: 0.1},
+            "a.rb:5": {id: "a.rb:5", file_path: "a.rb", expected_run_time: 0.1}
           }
         end
 
-        it { is_expected.to eq([404, {"content-type" => "text/plain"}, ["This is not the path you're looking for, 'ol chap..."]]) } # 404 since there are no more items in the pending queue
-        it { expect { subject }.to change { run_times.reload.length }.from(0).to(2) }
-        it { expect { subject }.to change { processing.reload.length }.from(2).to(1) }
-        it { expect { subject }.to change { completed.reload.length }.from(0).to(1) }
+        it { is_expected.to eq([404, {"content-type" => "text/plain", "x-specwrk-status" => "1"}, ["This is not the path you're looking for, 'ol chap..."]]) } # 404 since there are no more items in the pending queue
+        it { expect { subject }.to change { run_times.reload.length }.from(0).to(4) }
+        it { expect { subject }.to change { processing.reload.length }.from(4).to(1) }
+        it { expect { subject }.to change { completed.reload.length }.from(0).to(3) }
+        it { expect { subject }.to change { worker["passed"] }.from(nil).to(1) }
+        it { expect { subject }.to change { worker["failed"] }.from(nil).to(1) }
+        it { expect { subject }.to change { worker["pending"] }.from(nil).to(1) }
       end
 
       context "successfully pops an item off the queue" do
@@ -204,13 +212,9 @@ RSpec.describe Specwrk::Web::Endpoints do
           {"a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}}
         end
 
-        it { is_expected.to eq([200, {"content-type" => "application/json"}, [JSON.generate([{id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}])]]) }
+        it { is_expected.to eq([200, {"content-type" => "application/json", "x-specwrk-status" => "0"}, [JSON.generate([{id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}])]]) }
         it { expect { subject }.to change { pending.reload.length }.from(1).to(0) }
         it { expect { subject }.to change { processing.reload["a.rb:2"] }.from(nil).to({completion_threshold: instance_of(Integer), expected_run_time: 0.1, file_path: "a.rb", id: "a.rb:2"}) }
-      end
-
-      context "no items in any queue" do
-        it { is_expected.to eq([204, {"content-type" => "text/plain"}, ["Waiting for sample to be seeded."]]) }
       end
 
       context "no items in the processing queue, but completed queue has items" do
@@ -218,7 +222,7 @@ RSpec.describe Specwrk::Web::Endpoints do
           {"a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}}
         end
 
-        it { is_expected.to eq([410, {"content-type" => "text/plain"}, ["That's a good lad. Run along now and go home."]]) }
+        it { is_expected.to eq([410, {"content-type" => "text/plain", "x-specwrk-status" => "0"}, ["That's a good lad. Run along now and go home."]]) }
       end
 
       context "no items in the pending queue, but something in the processing queue but none are expired" do
@@ -226,7 +230,7 @@ RSpec.describe Specwrk::Web::Endpoints do
           {"a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}}
         end
 
-        it { is_expected.to eq([404, {"content-type" => "text/plain"}, ["This is not the path you're looking for, 'ol chap..."]]) }
+        it { is_expected.to eq([404, {"content-type" => "text/plain", "x-specwrk-status" => "0"}, ["This is not the path you're looking for, 'ol chap..."]]) }
       end
 
       context "no items in the pending queue, but something in the processing queue it is expired" do
@@ -234,7 +238,7 @@ RSpec.describe Specwrk::Web::Endpoints do
           {"a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1, completion_threshold: (Time.now - 1).to_i}}
         end
 
-        it { is_expected.to eq([200, {"content-type" => "application/json"}, [JSON.generate([existing_processing_data.values.first])]]) }
+        it { is_expected.to eq([200, {"content-type" => "application/json", "x-specwrk-status" => "0"}, [JSON.generate([existing_processing_data.values.first])]]) }
         it { expect { subject }.to change { processing["a.rb:2"][:completion_threshold] } }
       end
     end

--- a/spec/specwrk/web/endpoints_spec.rb
+++ b/spec/specwrk/web/endpoints_spec.rb
@@ -143,12 +143,12 @@ RSpec.describe Specwrk::Web::Endpoints do
         it { is_expected.to eq([204, {"content-type" => "text/plain", "x-specwrk-status" => "1"}, ["Waiting for sample to be seeded."]]) }
       end
 
-      context "no items in the processing queue, but completed queue has items" do
+      context "no items in the processing queue, no known failed for worker, but completed queue has items" do
         let(:existing_completed_data) do
           {"a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}}
         end
 
-        it { is_expected.to eq([410, {"content-type" => "text/plain", "x-specwrk-status" => "1"}, ["That's a good lad. Run along now and go home."]]) }
+        it { is_expected.to eq([410, {"content-type" => "text/plain", "x-specwrk-status" => "0"}, ["That's a good lad. Run along now and go home."]]) }
       end
 
       context "no items in the pending queue, but something in the processing queue but none are expired" do

--- a/spec/specwrk/worker/completion_formatter_spec.rb
+++ b/spec/specwrk/worker/completion_formatter_spec.rb
@@ -38,16 +38,6 @@ RSpec.describe Specwrk::Worker::CompletionFormatter do
       end
 
       it { expect { subject }.to change(instance.examples, :length).from(0).to(2) }
-      it { expect { subject }.not_to change(instance, :failure) }
-    end
-
-    context "a example failed" do
-      let(:notifications) do
-        [notification_factory(:failed), notification_factory(:passed)]
-      end
-
-      it { expect { subject }.to change(instance.examples, :length).from(0).to(2) }
-      it { expect { subject }.to change(instance, :failure).from(false).to(true) }
     end
   end
 end

--- a/spec/specwrk/worker/executor_spec.rb
+++ b/spec/specwrk/worker/executor_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe Specwrk::Worker::Executor do
         .and_return("🇺🇸!Big Success!🇺🇸")
 
       expect(instance.run(examples)).to eq("🇺🇸!Big Success!🇺🇸")
-      expect(instance.example_processed).to eq(true)
     end
   end
 

--- a/spec/specwrk/worker/executor_spec.rb
+++ b/spec/specwrk/worker/executor_spec.rb
@@ -3,12 +3,6 @@ require "specwrk/worker/executor"
 RSpec.describe Specwrk::Worker::Executor do
   let(:instance) { described_class.new }
 
-  describe "#failure" do
-    subject { instance.failure }
-
-    it { is_expected.to be(instance.completion_formatter.failure) }
-  end
-
   describe "#examples" do
     subject { instance.examples }
 

--- a/spec/specwrk/worker_spec.rb
+++ b/spec/specwrk/worker_spec.rb
@@ -8,14 +8,12 @@ RSpec.describe Specwrk::Worker do
   let(:thread) { instance_double(Thread, kill: true) }
 
   let(:instance) { described_class.new }
-  let(:failure) { false }
   let(:example_processed) { true }
 
   let(:executor) do
     instance_double Specwrk::Worker::Executor,
       final_output: tempfile,
       examples: %w[a.rb:1 b.rb:2],
-      failure: failure,
       example_processed: example_processed
   end
 

--- a/spec/specwrk/worker_spec.rb
+++ b/spec/specwrk/worker_spec.rb
@@ -8,13 +8,11 @@ RSpec.describe Specwrk::Worker do
   let(:thread) { instance_double(Thread, kill: true) }
 
   let(:instance) { described_class.new }
-  let(:example_processed) { true }
 
   let(:executor) do
     instance_double Specwrk::Worker::Executor,
       final_output: tempfile,
-      examples: %w[a.rb:1 b.rb:2],
-      example_processed: example_processed
+      examples: %w[a.rb:1 b.rb:2]
   end
 
   before do
@@ -75,8 +73,6 @@ RSpec.describe Specwrk::Worker do
     end
 
     context "no examples processed" do
-      let(:example_processed) { nil }
-
       before { allow(Specwrk::Client).to receive(:wait_for_server!) }
 
       it "returns 0 when no examples were processed, but server signals all examples completed" do
@@ -108,7 +104,7 @@ RSpec.describe Specwrk::Worker do
       it "breaks the loop" do
         count = 0
         expect(instance).to receive(:execute).exactly(4).times
-        expect(Specwrk).to receive(:force_quit).exactly(6).times do
+        expect(Specwrk).to receive(:force_quit).exactly(5).times do
           count += 1
           count >= 5
         end
@@ -145,8 +141,6 @@ RSpec.describe Specwrk::Worker do
     end
 
     context "calls run_examples when WaitingForSeedError" do
-      let(:example_processed) { nil }
-
       before { allow(Specwrk::Client).to receive(:wait_for_server!) }
 
       it "waits up to 10s before exiting" do

--- a/spec/specwrk/worker_spec.rb
+++ b/spec/specwrk/worker_spec.rb
@@ -76,13 +76,15 @@ RSpec.describe Specwrk::Worker do
       before { allow(Specwrk::Client).to receive(:wait_for_server!) }
 
       it "returns 0 when no examples were processed, but server signals all examples completed" do
+        expect(client).to receive(:worker_status)
+          .and_return(0)
         expect(instance).to receive(:execute)
           .and_raise(Specwrk::CompletedAllExamplesError)
 
         expect(subject).to eq(0)
       end
 
-      it "returns 1 when no examples were processed, but server did not signal all examples completed" do
+      it "returns client's worker_status when no examples were processed, but server did not signal all examples completed" do
         expect(instance).to receive(:sleep)
           .with(1)
           .exactly(10).times
@@ -94,7 +96,10 @@ RSpec.describe Specwrk::Worker do
           .and_raise(Specwrk::WaitingForSeedError)
           .exactly(11).times
 
-        expect(subject).to eq(1)
+        expect(client).to receive(:worker_status)
+          .and_return(42)
+
+        expect(subject).to eq(42)
       end
     end
 
@@ -104,7 +109,7 @@ RSpec.describe Specwrk::Worker do
       it "breaks the loop" do
         count = 0
         expect(instance).to receive(:execute).exactly(4).times
-        expect(Specwrk).to receive(:force_quit).exactly(5).times do
+        expect(Specwrk).to receive(:force_quit).exactly(6).times do
           count += 1
           count >= 5
         end
@@ -122,6 +127,9 @@ RSpec.describe Specwrk::Worker do
       before { allow(Specwrk::Client).to receive(:wait_for_server!) }
 
       it "breaks the loop and returns 0" do
+        expect(client).to receive(:worker_status)
+          .and_return(0)
+
         count = 1
         expect(instance).to receive(:execute).exactly(5).times do
           if count == 5
@@ -159,7 +167,10 @@ RSpec.describe Specwrk::Worker do
         expect(instance).to receive(:warn)
           .with("No examples seeded, giving up!")
 
-        expect(subject).to eq(1)
+        expect(client).to receive(:worker_status)
+          .and_return(42)
+
+        expect(subject).to eq(42)
       end
     end
 
@@ -167,6 +178,9 @@ RSpec.describe Specwrk::Worker do
       before { allow(Specwrk::Client).to receive(:wait_for_server!) }
 
       it "sleeps but doesn't break loop" do
+        expect(client).to receive(:worker_status)
+          .and_return(0)
+
         completed = false
         expect(instance).to receive(:sleep)
           .with(0.5)


### PR DESCRIPTION
Tracks the number of succeeded, pending, and most importantly failed examples processes per-worker. This is then used to instruct the worker process how to exit.

Fixes #97