### PR TITLE
Add support for example retries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,8 @@ jobs:
       ## SPECWRK STEP ##
       - run:
           name: Run tests via specwrk start
-          command: bundle exec specwrk start --count 2 spec/
+          # This run will output a single failure when healthy, but because of retries the exit code will be zero
+          command: bundle exec specwrk start --count 2 --max-retries 1 spec/
       ## /SPECWRK STEP ##
         
       ## SPECWRK STEP ##

--- a/.github/workflows/specwrk-single-node.yml
+++ b/.github/workflows/specwrk-single-node.yml
@@ -37,5 +37,6 @@ jobs:
 
       ## SPECWRK STEP ##
       - name: Run tests via specwrk start
-        run: bundle exec specwrk start --count 2 spec/
+        # This run will output a single failure when healthy, but because of retries the exit code will be zero
+        run: bundle exec specwrk start --count 2 --retries 1 spec/
       ## /SPECWRK STEP ##

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Specwrk
-Run your [RSpec](https://github.com/rspec/rspec) examples across many processors and many nodes for a single build. Or just many processes on a single node. Speeds up your *slow* (minutes/hours not seconds) test suite by running multiple examples in parallel.
+Run your [RSpec](https://github.com/rspec/rspec) examples across many processors and many nodes for a single build. Or just many processes on a single node. Speeds up your *slow* (minutes/hours not seconds) test suite by running multiple examples in parallel. Optionally, retry failed examples up-to N-times to avoid breaking deployments.
 
 One CLI command to:
 
@@ -60,6 +60,7 @@ Options:
   --store-uri=VALUE                 # Directory where server state is stored. Required for multi-node or multi-process servers.
   --group-by=VALUE                  # How examples will be grouped for workers; fallback to file if no timings are found. Overrides SPECWERK_SRV_GROUP_BY: (file/timings), default: "timings"
   --[no-]verbose                    # Run in verbose mode, default: false
+  --max-retries=VALUE               # Number of times an example will be re-run should it fail, default: 0
   --help, -h                        # Print this help
 ```
 
@@ -111,6 +112,7 @@ Options:
   --key=VALUE, -k VALUE             # Authentication key clients must use for access. Overrides SPECWRK_SRV_KEY, default: ""
   --run=VALUE, -r VALUE             # The run identifier for this job execution. Overrides SPECWRK_RUN, default: "main"
   --timeout=VALUE, -t VALUE         # The amount of time to wait for the server to respond. Overrides SPECWRK_TIMEOUT, default: "5"
+  --max-retries=VALUE               # Number of times an example will be re-run should it fail, default: 0
   --help, -h                        # Print this help
 ```
 

--- a/lib/specwrk/client.rb
+++ b/lib/specwrk/client.rb
@@ -128,7 +128,7 @@ module Specwrk
     end
 
     def seed(examples)
-      response = post "/seed", body: examples.to_json
+      response = post "/seed", body: {examples: examples}.to_json
 
       (response.code == "200") ? true : raise(UnhandledResponseError.new("#{response.code}: #{response.body}"))
     end

--- a/lib/specwrk/client.rb
+++ b/lib/specwrk/client.rb
@@ -127,8 +127,8 @@ module Specwrk
       retry
     end
 
-    def seed(examples)
-      response = post "/seed", body: {examples: examples}.to_json
+    def seed(examples, max_retries)
+      response = post "/seed", body: {max_retries: max_retries, examples: examples}.to_json
 
       (response.code == "200") ? true : raise(UnhandledResponseError.new("#{response.code}: #{response.body}"))
     end

--- a/lib/specwrk/store.rb
+++ b/lib/specwrk/store.rb
@@ -139,7 +139,8 @@ module Specwrk
 
     def merge!(hash)
       super
-      self.order = hash.keys
+
+      self.order = order + (hash.keys - order)
     end
 
     def clear

--- a/lib/specwrk/store.rb
+++ b/lib/specwrk/store.rb
@@ -99,6 +99,7 @@ module Specwrk
   class PendingStore < Store
     RUN_TIME_BUCKET_MAXIMUM_KEY = :____run_time_bucket_maximum
     ORDER_KEY = :____order
+    MAX_RETRIES_KEY = :____max_retries
 
     def run_time_bucket_maximum=(val)
       @run_time_bucket_maximum = self[RUN_TIME_BUCKET_MAXIMUM_KEY] = val
@@ -122,6 +123,14 @@ module Specwrk
       @order ||= self[ORDER_KEY] || []
     end
 
+    def max_retries=(val)
+      @max_retries = self[MAX_RETRIES_KEY] = val
+    end
+
+    def max_retries
+      @max_retries ||= self[MAX_RETRIES_KEY] || 0
+    end
+
     def keys
       return super if order.length.zero?
 
@@ -140,6 +149,7 @@ module Specwrk
 
     def reload
       @order = nil
+      @max_retries = nil
       super
     end
 

--- a/lib/specwrk/web/endpoints.rb
+++ b/lib/specwrk/web/endpoints.rb
@@ -142,6 +142,8 @@ module Specwrk
         def with_response
           pending.clear
 
+          pending.max_retries = payload.fetch(:max_retries, 0)
+
           new_run_time_bucket_maximums = [pending.run_time_bucket_maximum, @seeds_run_time_bucket_maximum.to_f].compact
           pending.run_time_bucket_maximum = new_run_time_bucket_maximums.sum.to_f / new_run_time_bucket_maximums.length.to_f
 

--- a/lib/specwrk/web/endpoints.rb
+++ b/lib/specwrk/web/endpoints.rb
@@ -141,6 +141,7 @@ module Specwrk
 
         def with_response
           pending.clear
+
           new_run_time_bucket_maximums = [pending.run_time_bucket_maximum, @seeds_run_time_bucket_maximum.to_f].compact
           pending.run_time_bucket_maximum = new_run_time_bucket_maximums.sum.to_f / new_run_time_bucket_maximums.length.to_f
 
@@ -154,10 +155,10 @@ module Specwrk
         def examples_with_run_times
           @examples_with_run_times ||= begin
             unsorted_examples_with_run_times = []
-            all_ids = payload.map { |example| example[:id] }
+            all_ids = payload[:examples].map { |example| example[:id] }
             all_run_times = run_times.multi_read(*all_ids)
 
-            payload.each do |example|
+            payload[:examples].each do |example|
               run_time = all_run_times[example[:id]]
 
               unsorted_examples_with_run_times << [example[:id], example.merge(expected_run_time: run_time)]

--- a/lib/specwrk/web/endpoints.rb
+++ b/lib/specwrk/web/endpoints.rb
@@ -92,6 +92,10 @@ module Specwrk
           @completed ||= CompletedStore.new(ENV.fetch("SPECWRK_SRV_STORE_URI", "memory:///"), File.join(run_id, "completed"))
         end
 
+        def failure_counts
+          @failure_counts ||= Store.new(ENV.fetch("SPECWRK_SRV_STORE_URI", "memory:///"), File.join(run_id, "failure_counts"))
+        end
+
         def metadata
           @metadata ||= Store.new(ENV.fetch("SPECWRK_SRV_STORE_URI", "memory:///"), File.join(run_id, "metadata"))
         end
@@ -141,6 +145,7 @@ module Specwrk
 
         def with_response
           pending.clear
+          failure_counts.clear
 
           pending.max_retries = payload.fetch(:max_retries, 0)
 
@@ -253,15 +258,52 @@ module Specwrk
 
         def with_response
           completed.merge!(completed_examples)
-          processing.delete(*completed_examples.keys)
+          processing.delete(*(completed_examples.keys + retry_examples.keys))
+          pending.merge!(retry_examples)
+          failure_counts.merge!(retry_examples_new_failure_counts)
 
           with_pop_response
         end
 
         private
 
+        def all_examples
+          @all_examples ||= payload.map { |example| [example[:id], example] if processing[example[:id]] }.compact.to_h
+        end
+
         def completed_examples
-          @completed_data ||= payload.map { |example| [example[:id], example] if processing[example[:id]] }.compact.to_h
+          @completed_examples ||= all_examples.map do |id, example|
+            next if retry_example?(example)
+
+            [id, example]
+          end.compact.to_h
+        end
+
+        def retry_examples
+          @retry_examples ||= all_examples.map do |id, example|
+            next unless retry_example?(example)
+
+            [id, example]
+          end.compact.to_h
+        end
+
+        def retry_examples_new_failure_counts
+          @retry_examples_new_failure_counts ||= retry_examples.map do |id, _example|
+            [id, all_example_failure_counts.fetch(id, 0) + 1]
+          end.to_h
+        end
+
+        def retry_example?(example)
+          return false unless example[:status] == "failed"
+          return false unless pending.max_retries.positive?
+
+          example_failure_count = all_example_failure_counts.fetch(example[:id], 0)
+
+          example_failure_count < pending.max_retries
+        end
+
+        def all_example_failure_counts
+          @all_example_failure_counts ||= failure_counts.multi_read(*all_examples.keys)
         end
 
         def completed_examples_status_counts

--- a/lib/specwrk/web/endpoints.rb
+++ b/lib/specwrk/web/endpoints.rb
@@ -147,7 +147,7 @@ module Specwrk
           pending.clear
           failure_counts.clear
 
-          pending.max_retries = payload.fetch(:max_retries, 0)
+          pending.max_retries = payload.fetch(:max_retries, "0").to_i
 
           new_run_time_bucket_maximums = [pending.run_time_bucket_maximum, @seeds_run_time_bucket_maximum.to_f].compact
           pending.run_time_bucket_maximum = new_run_time_bucket_maximums.sum.to_f / new_run_time_bucket_maximums.length.to_f

--- a/lib/specwrk/worker.rb
+++ b/lib/specwrk/worker.rb
@@ -54,7 +54,7 @@ module Specwrk
         end
       end
 
-      executor.final_output.tap(&:rewind).each_line { |line| $stdout.write line }
+      executor.final_output.tap(&:rewind).each_line { |line| final_output.write line }
 
       @heartbeat_thread.kill
       client.close
@@ -108,6 +108,10 @@ module Specwrk
     private
 
     attr_reader :running, :client, :executor
+
+    def final_output
+      $final_output || $stdout
+    end
 
     def status
       return 0 if @all_examples_completed && client.worker_status.zero?

--- a/spec/specwrk/client_spec.rb
+++ b/spec/specwrk/client_spec.rb
@@ -325,10 +325,11 @@ RSpec.describe Specwrk::Client do
   end
 
   describe "#seed" do
-    subject { client.seed(payload) }
+    subject { client.seed(examples, max_retries) }
 
     let(:client) { described_class.new }
-    let(:payload) { [{id: 1}] }
+    let(:examples) { [{id: 1}] }
+    let(:max_retries) { 5 }
 
     context "when response is 200" do
       before do

--- a/spec/specwrk/store_spec.rb
+++ b/spec/specwrk/store_spec.rb
@@ -153,11 +153,15 @@ RSpec.describe Specwrk::PendingStore do
   end
 
   describe "#merge!" do
-    subject { instance.merge!(:alpha => 1, "beta" => 2) }
+    subject { instance.merge!(:gamma => 3, :alpha => 1, "beta" => 2) }
 
-    before { instance["alpha"] = 0 }
+    before do
+      instance["alpha"] = 0
+      instance.order = ["alpha", "nonexistant"]
+    end
 
-    it { expect { subject }.to change(instance, :inspect).from(alpha: 0).to(alpha: 1, beta: 2) }
+    it { expect { subject }.to change(instance, :inspect).from(alpha: 0).to(alpha: 1, beta: 2, gamma: 3) }
+    it { expect { subject }.to change(instance, :order).from(%w[alpha nonexistant]).to(%w[alpha nonexistant gamma beta]) }
   end
 
   describe "#shift_bucket" do

--- a/spec/specwrk/store_spec.rb
+++ b/spec/specwrk/store_spec.rb
@@ -138,6 +138,20 @@ RSpec.describe Specwrk::PendingStore do
     end
   end
 
+  describe "#max_retries=" do
+    subject { instance.max_retries = 3 }
+
+    it { expect { subject }.to change(instance, :max_retries).from(0).to(3) }
+  end
+
+  describe "#max_retries" do
+    subject { instance.max_retries }
+
+    before { instance[described_class::MAX_RETRIES_KEY] = 4 }
+
+    it { is_expected.to eq(4) }
+  end
+
   describe "#merge!" do
     subject { instance.merge!(:alpha => 1, "beta" => 2) }
 

--- a/spec/specwrk/web/endpoints_spec.rb
+++ b/spec/specwrk/web/endpoints_spec.rb
@@ -84,16 +84,17 @@ RSpec.describe Specwrk::Web::Endpoints do
 
     describe Specwrk::Web::Endpoints::Seed do
       let(:request_method) { "POST" }
-      let(:body) { JSON.generate(examples: [{id: "a.rb:1", file_path: "a.rb", run_time: 0.1}]) }
+      let(:body) { JSON.generate(max_retries: 42, examples: [{id: "a.rb:1", file_path: "a.rb", run_time: 0.1}]) }
 
-      context "pending store reset with examples" do
+      context "pending store reset with examples and meta data" do
         let(:existing_pending_data) { {"b.rb:2" => {id: "b.rb:2", file_path: "b.rb", expected_run_time: 0.1}} }
 
         it { is_expected.to eq(ok) }
         it { expect { subject }.to change(pending, :inspect).from("b.rb:2": instance_of(Hash)).to("a.rb:1": instance_of(Hash)) }
+        it { expect { subject }.to change { pending.reload.max_retries }.from(0).to(42) }
       end
 
-      context "merged with expected_run_time sorted by file" do
+      context "merged with  sorted by file" do
         let(:body) do
           JSON.generate(examples: [
             {id: "a.rb:1", file_path: "a.rb"},
@@ -105,7 +106,7 @@ RSpec.describe Specwrk::Web::Endpoints do
         it { expect { subject }.to change { pending.reload.keys }.from([]).to(%w[a.rb:1 a.rb:2 b.rb:1]) }
       end
 
-      context "merged with expected_run_time sorted by timings" do
+      context "merged with run_time_bucket_maximum sorted by timings" do
         let(:existing_run_times_data) do
           {
             "a.rb:1": 0.2,

--- a/spec/specwrk/web/endpoints_spec.rb
+++ b/spec/specwrk/web/endpoints_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Specwrk::Web::Endpoints do
 
     describe Specwrk::Web::Endpoints::Seed do
       let(:request_method) { "POST" }
-      let(:body) { JSON.generate([{id: "a.rb:1", file_path: "a.rb", run_time: 0.1}]) }
+      let(:body) { JSON.generate(examples: [{id: "a.rb:1", file_path: "a.rb", run_time: 0.1}]) }
 
       context "pending store reset with examples" do
         let(:existing_pending_data) { {"b.rb:2" => {id: "b.rb:2", file_path: "b.rb", expected_run_time: 0.1}} }
@@ -95,7 +95,7 @@ RSpec.describe Specwrk::Web::Endpoints do
 
       context "merged with expected_run_time sorted by file" do
         let(:body) do
-          JSON.generate([
+          JSON.generate(examples: [
             {id: "a.rb:1", file_path: "a.rb"},
             {id: "b.rb:1", file_path: "b.rb"},
             {id: "a.rb:2", file_path: "a.rb"}
@@ -115,7 +115,7 @@ RSpec.describe Specwrk::Web::Endpoints do
         end
 
         let(:body) do
-          JSON.generate([
+          JSON.generate(examples: [
             {id: "a.rb:1", file_path: "a.rb"},
             {id: "a.rb:2", file_path: "a.rb"},
             {id: "b.rb:3", file_path: "b.rb"},

--- a/spec/specwrk/worker_spec.rb
+++ b/spec/specwrk/worker_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe Specwrk::Worker do
       .with("bar")
   end
 
+  around do |ex|
+    final_output_reference = $final_output
+    $final_output = nil
+    ex.run
+    $final_output = final_output_reference
+  end
+
   describe ".run!" do
     subject { described_class.run! }
 

--- a/spec/specwrk_spec.rb
+++ b/spec/specwrk_spec.rb
@@ -36,4 +36,26 @@ RSpec.describe Specwrk do
       it { is_expected.to eq(pid1 => 1, pid2 => 42) }
     end
   end
+
+  if ENV["SPECWRK_SRV_URI"].nil? && ENV["SPECWRK_FORKED"]
+    describe "a test that only passes on the second retry on the same instance (assume max retries > 0)" do
+      it "should succeed on the 2nd run" do
+        file = File.join(Dir.tmpdir, "specwrk.retry")
+
+        count = if File.exist?(file)
+          JSON.parse(File.read(file))
+        else
+          0
+        end
+
+        File.write(file, JSON.generate(count + 1))
+        if count.zero?
+          expect(true).to eq(false)
+        else
+          expect(true).to eq(true)
+          FileUtils.rm_rf(file)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Mostly fixes #96, however, we are not yet reporting flakes explicitly.

- Supports --max-retries for `start` and `seed` commands. Default is `0` retries
- Will exit with a zero status code if an example fails but then succeeds within the retry limit
- Will exit with non-zero status code if example fails > retry limit