### PR TITLE
Clear filter manager inclusions and exclusions when listing examples

### DIFF
--- a/lib/specwrk/list_examples.rb
+++ b/lib/specwrk/list_examples.rb
@@ -59,6 +59,8 @@ module Specwrk
       RSpec.world.wants_to_quit = Specwrk.force_quit
 
       RSpec.configuration.silence_filter_announcements = true
+      RSpec.configuration.filter_manager.inclusions.clear
+      RSpec.configuration.filter_manager.exclusions.clear
 
       true
     end


### PR DESCRIPTION
Fixe #121