### PR TITLE
rspec-core is a runtime dependency, rspec is not

### DIFF
--- a/lib/specwrk/cli_reporter.rb
+++ b/lib/specwrk/cli_reporter.rb
@@ -4,7 +4,7 @@ require "time"
 
 require "specwrk/client"
 
-require "rspec"
+require "rspec/core"
 require "rspec/core/formatters/helpers"
 require "rspec/core/formatters/console_codes"
 

--- a/lib/specwrk/worker/executor.rb
+++ b/lib/specwrk/worker/executor.rb
@@ -2,7 +2,7 @@
 
 require "tempfile"
 
-require "rspec"
+require "rspec/core"
 
 require "specwrk/worker/progress_formatter"
 require "specwrk/worker/completion_formatter"


### PR DESCRIPTION
First time running specwrk, I got this stacktrace:

    /Users/bquorning/.rubies/ruby-3.4.4/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require': cannot load such file -- rspec (LoadError)
      from /Users/bquorning/.rubies/ruby-3.4.4/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
      from /Users/bquorning/.gem/ruby/3.4.4/gems/specwrk-0.15.3/lib/specwrk/worker/executor.rb:5:in '<top (required)>'
