### PR TITLE
Support an array of arguments when seeding/starting

### DIFF
--- a/lib/specwrk/cli.rb
+++ b/lib/specwrk/cli.rb
@@ -131,7 +131,7 @@ module Specwrk
 
       desc "Seed the server with a list of specs for the run"
       option :max_retries, default: 0, desc: "Number of times an example will be re-run should it fail"
-      argument :dir, required: false, default: "spec", desc: "Relative spec directory to run against"
+      argument :dir, type: :array, required: false, default: "spec", desc: "Relative spec directory to run against"
 
       def call(max_retries:, dir:, **args)
         self.class.setup(**args)
@@ -208,7 +208,7 @@ module Specwrk
 
       desc "Start a server and workers, monitor until complete"
       option :max_retries, default: 0, desc: "Number of times an example will be re-run should it fail"
-      argument :dir, required: false, default: "spec", desc: "Relative spec directory to run against"
+      argument :dir, required: false, type: :array, default: "spec", desc: "Relative spec directory to run against"
 
       def call(max_retries:, dir:, **args)
         self.class.setup(**args)


### PR DESCRIPTION
Fixes #140

```sh
 ➜  specwrk git:(seed-and-start-many-files) ✗ be exe/specwrk start -c 4 spec/specwrk/list_examples_spec.rb
4 workers started ✓
...
Finished in 0.26s (total execution time of 0.78s)
3 examples, 0 failures
➜  specwrk git:(seed-and-start-many-files) ✗ be exe/specwrk start -c 4 spec/specwrk_spec.rb
4 workers started ✓
...
Finished in 0.69s (total execution time of 1.51s)
3 examples, 0 failures
➜  specwrk git:(seed-and-start-many-files) ✗ be exe/specwrk start -c 4 spec/specwrk_spec.rb spec/specwrk/list_examples_spec.rb
4 workers started ✓
......
Finished in 0.68s (total execution time of 2.27s)
6 examples, 0 failures
```