### PR TITLE
Expire workers from worker heartbeats

### DIFF
--- a/lib/specwrk/web/endpoints/popable.rb
+++ b/lib/specwrk/web/endpoints/popable.rb
@@ -32,7 +32,7 @@ module Specwrk
 
             processing_data = examples.map do |example|
               [
-                example[:id], example.merge(worker_id: worker_id)
+                example[:id], example.merge(worker_id: worker_id, processing_started_at: Time.now.to_i)
               ]
             end
 
@@ -51,6 +51,8 @@ module Specwrk
         # Has the worker missed two heartbeat check-ins?
         def expired?(example)
           return false unless example[:worker_id]
+          return false unless example[:processing_started_at]
+          return false unless example[:processing_started_at] < (Time.now - 20).to_i
 
           workers_last_heartbeats[example[:worker_id]] < Time.now - 20
         end

--- a/lib/specwrk/web/endpoints/popable.rb
+++ b/lib/specwrk/web/endpoints/popable.rb
@@ -15,9 +15,9 @@ module Specwrk
             [204, {"content-type" => "text/plain"}, ["Waiting for sample to be seeded."]]
           elsif completed.any? && processing.empty?
             [410, {"content-type" => "text/plain"}, ["That's a good lad. Run along now and go home."]]
-          elsif processing.any? && processing.expired.keys.any?
-            pending.merge!(processing.expired)
-            processing.delete(*processing.expired.keys)
+          elsif expired_examples.length.positive?
+            pending.merge!(expired_examples.each { |_id, example| example[:worker_id] = worker_id })
+            processing.delete(*expired_examples.keys)
             @examples = nil
 
             [200, {"content-type" => "application/json"}, [JSON.generate(examples)]]
@@ -29,19 +29,35 @@ module Specwrk
         def examples
           @examples ||= begin
             examples = pending.shift_bucket
-            bucket_run_time_total = examples.map { |example| example.fetch(:expected_run_time, 10.0) }.compact.sum * 2
-            maximum_completion_threshold = (pending.run_time_bucket_maximum || 30.0) * 2
-            completion_threshold = Time.now + [bucket_run_time_total, maximum_completion_threshold, 20.0].max
 
             processing_data = examples.map do |example|
               [
-                example[:id], example.merge(completion_threshold: completion_threshold.to_f)
+                example[:id], example.merge(worker_id: worker_id)
               ]
             end
 
             processing.merge!(processing_data.to_h)
 
             examples
+          end
+        end
+
+        def expired_examples
+          return unless processing.any?
+
+          @expired_examples ||= processing.to_h.select { |_id, example| expired?(example) }
+        end
+
+        # Has the worker missed two heartbeat check-ins?
+        def expired?(example)
+          return false unless example[:worker_id]
+
+          workers_last_heartbeats[example[:worker_id]] < Time.now - 20
+        end
+
+        def workers_last_heartbeats
+          @workers_last_heartbeats ||= Hash.new do |h, k|
+            h[k] = worker_store_for(k).last_seen_at || Time.at(0)
           end
         end
       end

--- a/spec/specwrk/store_spec.rb
+++ b/spec/specwrk/store_spec.rb
@@ -122,6 +122,47 @@ RSpec.describe Specwrk::Store do
   end
 end
 
+RSpec.describe Specwrk::WorkerStore do
+  let(:uri_string) { "file://#{Dir.tmpdir}" }
+  let(:scope) { SecureRandom.uuid }
+
+  let(:instance) { described_class.new(uri_string, scope) }
+  let!(:time) { Time.now.round(0) }
+
+  before do
+    instance.clear
+    allow(Time).to receive(:now).and_return(time)
+  end
+
+  describe "#first_seen_at=" do
+    subject { instance.first_seen_at = time - 100 }
+
+    it { expect { subject }.to change(instance, :first_seen_at).from(nil).to(time - 100) }
+  end
+
+  describe "#first_seen_at" do
+    subject { instance.first_seen_at }
+
+    before { instance[described_class::FIRST_SEEN_AT_KEY] = 812 }
+
+    it { is_expected.to eq(Time.at(812)) }
+  end
+
+  describe "#last_seen_at=" do
+    subject { instance.last_seen_at = time - 100 }
+
+    it { expect { subject }.to change(instance, :last_seen_at).from(nil).to(time - 100) }
+  end
+
+  describe "#last_seen_at" do
+    subject { instance.last_seen_at }
+
+    before { instance[described_class::LAST_SEEN_AT_KEY] = 812 }
+
+    it { is_expected.to eq(Time.at(812)) }
+  end
+end
+
 RSpec.describe Specwrk::PendingStore do
   let(:uri_string) { "file://#{Dir.tmpdir}" }
   let(:scope) { SecureRandom.uuid }
@@ -306,31 +347,8 @@ RSpec.describe Specwrk::PendingStore do
     end
   end
 end
+
 RSpec.describe Specwrk::ProcessingStore do
-  let(:uri_string) { "file://#{Dir.tmpdir}" }
-  let(:scope) { SecureRandom.uuid }
-
-  let(:instance) { described_class.new(uri_string, scope) }
-
-  before { instance.clear }
-
-  describe "#expired" do
-    subject { instance.expired }
-
-    before do
-      allow(Time).to receive(:now).and_return(Time.at(1_000_000))
-
-      instance.merge!(
-        "past_item" => {completion_threshold: 500},
-        "exact_now_item" => {completion_threshold: 1_000_000},
-        "future_item" => {completion_threshold: 1_500_000},
-        "no_threshold" => {some_other_key: "foo"}
-      )
-    end
-
-    it { is_expected.to have_key("past_item") }
-    it { is_expected.not_to have_key("no_threshold") }
-  end
 end
 
 RSpec.describe Specwrk::CompletedStore do

--- a/spec/specwrk/web/endpoints/base_spec.rb
+++ b/spec/specwrk/web/endpoints/base_spec.rb
@@ -7,23 +7,31 @@ RSpec.describe Specwrk::Web::Endpoints::Base do
   include_context "worker endpoint"
 
   context "sets worker metadata at first look" do
-    let!(:time) { Time.now }
+    let!(:time) { Time.now.round(0) - 100 }
 
     before { allow(Time).to receive(:now).and_return(time) }
 
     it do
       expect { response }
-        .to change(worker, :inspect)
-        .from({})
-        .to(first_seen_at: time.iso8601, last_seen_at: time.iso8601)
+        .to change { worker.reload.first_seen_at }
+        .from(nil)
+        .to(time)
+    end
+
+    it do
+      expect { response }
+        .to change { worker.reload.last_seen_at }
+        .from(nil)
+        .to(time)
     end
   end
 
   context "updates worker metadata on subsequent look" do
     let(:existing_worker_data) do
-      {first_seen_at: (Time.now - 100).iso8601, last_seen_at: (Time.now - 100).iso8601}
+      {Specwrk::WorkerStore::FIRST_SEEN_AT_KEY => (Time.now - 100).to_i, Specwrk::WorkerStore::LAST_SEEN_AT_KEY => (Time.now - 100).to_i}
     end
 
-    it { expect { response }.to change(worker, :inspect) }
+    it { expect { response }.not_to change { worker.reload.first_seen_at } }
+    it { expect { response }.to change { worker.reload.last_seen_at } }
   end
 end

--- a/spec/specwrk/web/endpoints/complete_and_pop_spec.rb
+++ b/spec/specwrk/web/endpoints/complete_and_pop_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Specwrk::Web::Endpoints::CompleteAndPop do
 
     it { is_expected.to eq([200, {"content-type" => "application/json", "x-specwrk-status" => "0"}, [JSON.generate([{id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}])]]) }
     it { expect { subject }.to change { pending.reload.length }.from(1).to(0) }
-    it { expect { subject }.to change { processing.reload["a.rb:2"] }.from(nil).to({expected_run_time: 0.1, file_path: "a.rb", id: "a.rb:2", worker_id: "foobar-0"}) }
+    it { expect { subject }.to change { processing.reload["a.rb:2"] }.from(nil).to({expected_run_time: 0.1, file_path: "a.rb", id: "a.rb:2", worker_id: "foobar-0", processing_started_at: instance_of(Integer)}) }
   end
 
   context "no items in the processing queue, but completed queue has items" do
@@ -56,7 +56,7 @@ RSpec.describe Specwrk::Web::Endpoints::CompleteAndPop do
 
   context "no items in the pending queue, but something in the processing queue but none are expired" do
     let(:existing_processing_data) do
-      {"a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1, worker_id: other_worker_id}}
+      {"a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1, processing_started_at: (Time.now - 100).to_i, worker_id: other_worker_id}}
     end
 
     before { other_worker.last_seen_at = Time.now - 19 }
@@ -66,7 +66,7 @@ RSpec.describe Specwrk::Web::Endpoints::CompleteAndPop do
 
   context "no items in the pending queue, but something in the processing queue that is expired" do
     let(:existing_processing_data) do
-      {"a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1, worker_id: other_worker_id}}
+      {"a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1, processing_started_at: (Time.now - 100).to_i, worker_id: other_worker_id}}
     end
 
     before { other_worker.last_seen_at = Time.now - 21 }

--- a/spec/specwrk/web/endpoints/pop_spec.rb
+++ b/spec/specwrk/web/endpoints/pop_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Specwrk::Web::Endpoints::Pop do
 
     it { is_expected.to eq([200, {"content-type" => "application/json", "x-specwrk-status" => "1"}, [JSON.generate([{id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}])]]) }
     it { expect { subject }.to change { pending.reload.length }.from(1).to(0) }
-    it { expect { subject }.to change { processing.reload["a.rb:2"] }.from(nil).to({expected_run_time: 0.1, file_path: "a.rb", id: "a.rb:2", worker_id: "foobar-0"}) }
+    it { expect { subject }.to change { processing.reload["a.rb:2"] }.from(nil).to({expected_run_time: 0.1, file_path: "a.rb", id: "a.rb:2", worker_id: "foobar-0", processing_started_at: instance_of(Integer)}) }
   end
 
   context "no items in any queue" do

--- a/spec/specwrk/web/endpoints/pop_spec.rb
+++ b/spec/specwrk/web/endpoints/pop_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Specwrk::Web::Endpoints::Pop do
 
     it { is_expected.to eq([200, {"content-type" => "application/json", "x-specwrk-status" => "1"}, [JSON.generate([{id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}])]]) }
     it { expect { subject }.to change { pending.reload.length }.from(1).to(0) }
-    it { expect { subject }.to change { processing.reload["a.rb:2"] }.from(nil).to({completion_threshold: instance_of(Float), expected_run_time: 0.1, file_path: "a.rb", id: "a.rb:2"}) }
+    it { expect { subject }.to change { processing.reload["a.rb:2"] }.from(nil).to({expected_run_time: 0.1, file_path: "a.rb", id: "a.rb:2", worker_id: "foobar-0"}) }
   end
 
   context "no items in any queue" do

--- a/spec/support/specwrk/web/endpoints.rb
+++ b/spec/support/specwrk/web/endpoints.rb
@@ -36,7 +36,8 @@ RSpec.shared_context "worker endpoint" do
   let(:pending) { Specwrk::PendingStore.new datastore_uri, "pending" }
   let(:processing) { Specwrk::Store.new datastore_uri, "processing" }
   let(:completed) { Specwrk::CompletedStore.new datastore_uri, "completed" }
-  let(:worker) { Specwrk::PendingStore.new datastore_uri, File.join("workers", worker_id.to_s) }
+  let(:worker) { Specwrk::WorkerStore.new datastore_uri, File.join("workers", worker_id.to_s) }
+  let(:other_worker) { Specwrk::WorkerStore.new datastore_uri, File.join("workers", other_worker_id.to_s) }
   let(:failure_counts) { Specwrk::Store.new datastore_uri, "failure_counts" }
 
   let(:existing_run_times_data) { {} }
@@ -47,7 +48,8 @@ RSpec.shared_context "worker endpoint" do
   let(:existing_failure_counts_data) { {} }
 
   let(:run_id) { "main" }
-  let(:worker_id) { :"foobar-0" }
+  let(:worker_id) { "foobar-0" }
+  let(:other_worker_id) { "foobar-1" }
   let(:datastore_uri) { "file://#{datastore_path}" }
   let(:datastore_path) { File.join(base_path, run_id) }
   let(:base_uri) { "file://#{base_path}" }


### PR DESCRIPTION
Resolves #148 

Switches from trying to guess when an example will complete to checking if the worker that is processing the example has missed > 2 heartbeats (sent every 10s).