### PR TITLE
More frequent heartbeats

### DIFF
--- a/lib/specwrk/worker.rb
+++ b/lib/specwrk/worker.rb
@@ -98,7 +98,7 @@ module Specwrk
         sleep 10
 
         begin
-          client.heartbeat if client.last_request_at.nil? || client.last_request_at < Time.now - 30
+          client.heartbeat if client.last_request_at.nil? || client.last_request_at < Time.now - 9
         rescue
           warn "Heartbeat failed!"
         end

--- a/spec/specwrk/worker_spec.rb
+++ b/spec/specwrk/worker_spec.rb
@@ -305,9 +305,9 @@ RSpec.describe Specwrk::Worker do
         expect { instance.thump }.to raise_error("Boom")
       end
 
-      it "last request > 30 sec ago" do
+      it "last request > 9 sec ago" do
         allow(client).to receive(:last_request_at)
-          .and_return(Time.now - 31)
+          .and_return(Time.now - 9)
 
         expect(client).to receive(:heartbeat)
           .and_return(true)


### PR DESCRIPTION
Since #149 expires an example after 20sec w/o a heartbeat, we should increase the frequency to heartbeat at least every 9 sec to make sure we're showing appropriate signs of life.