### PR TITLE
If pending is empty, return before acquiring lock

### DIFF
--- a/lib/specwrk/web/endpoints/complete_and_pop.rb
+++ b/lib/specwrk/web/endpoints/complete_and_pop.rb
@@ -9,13 +9,14 @@ module Specwrk
         EXAMPLE_STATUSES = %w[passed failed pending]
 
         def with_response
-          completed.merge!(completed_examples)
-          processing.delete(*(completed_examples.keys + retry_examples.keys))
+          retry_examples # pre-calculate before lock
 
           with_lock do
+            processing.delete(*(completed_examples.keys + retry_examples.keys))
             pending.merge!(retry_examples)
           end
 
+          completed.merge!(completed_examples)
           failure_counts.merge!(retry_examples_new_failure_counts)
 
           update_run_times

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  config.order = :random
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
This *could* result in an extra worker request cycle if an example gets retried or expired, however, that is the edge case. In the real world there are many workers making requests so its likely another worker would pick it up.