### PR TITLE
Report unexecuted batch examples as failed instead of stranding them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased  
 [Compare](https://github.com/danielwestendorf/specwrk/compare/v0.19.2...main)  
+- Report batch examples the RSpec runner never executed (e.g. a `before(:suite)` error aborted the run) as failed, instead of silently stranding them in the server's processing store and hanging the whole run — by [@benjaminwood](https://github.com/benjaminwood)  
 
 ## v0.19.2 — 2025-12-09  
 [Compare](https://github.com/danielwestendorf/specwrk/compare/v0.19.1...v0.19.2)  

--- a/lib/specwrk/worker.rb
+++ b/lib/specwrk/worker.rb
@@ -70,9 +70,10 @@ module Specwrk
     end
 
     def execute
-      executor.run next_examples
+      batch = next_examples
+      executor.run batch
       @next_examples = nil
-      complete_examples
+      complete_examples batch
     rescue UnhandledResponseError => e
       # If fetching examples via next_exampels fails we can just try again so warn and return
       # Expects complete_examples to rescue this error if raised in that method
@@ -84,8 +85,8 @@ module Specwrk
       client.fetch_examples
     end
 
-    def complete_examples
-      @next_examples = client.complete_and_fetch_examples executor.examples
+    def complete_examples(batch = [])
+      @next_examples = client.complete_and_fetch_examples executor.examples + unexecuted_examples(batch)
     rescue UnhandledResponseError => e
       # I do not think we should so lightly abandon the completion of executed examples
       # try to complete until successful or terminated
@@ -93,6 +94,46 @@ module Specwrk
 
       sleep 1
       retry
+    end
+
+    # Failure results for examples that were part of the batch but which the
+    # RSpec runner produced no result for — e.g. the run aborted in a
+    # `before(:suite)` hook or a spec file failed to load, so zero examples
+    # executed.
+    #
+    # Every example popped from the server MUST be reported back. The server
+    # only removes examples from its processing store when a completion names
+    # them, and its expiry/requeue path only reclaims work from workers whose
+    # heartbeat has gone stale — a live worker's stranded examples are never
+    # reclaimed. If they were silently dropped here, `processing` would never
+    # empty, the run-complete condition could never be met, and every worker
+    # would poll for more work forever. Reporting them as failed lets the run
+    # finish loudly (and lets `--max-retries` retry them like any other
+    # failure).
+    def unexecuted_examples(batch)
+      return [] if batch.nil? || batch.empty?
+
+      executed_ids = executor.examples.map { |example| example[:id] }
+      now = Time.now
+
+      batch.reject { |example| executed_ids.include?(example[:id]) }.map do |example|
+        {
+          id: example[:id],
+          full_description: example[:full_description] || example[:id],
+          status: "failed",
+          file_path: example[:file_path],
+          line_number: example[:line_number],
+          started_at: now.iso8601(6),
+          finished_at: now.iso8601(6),
+          run_time: 0.0,
+          exception: {
+            class: "Specwrk::Error",
+            message: "Example was assigned to #{ENV.fetch("SPECWRK_ID", "specwrk-worker")} but the RSpec runner produced no result for it. " \
+                     "This usually means the run aborted before executing any examples — check for an error in a `before(:suite)` hook or a spec file that fails to load.",
+            backtrace: []
+          }
+        }
+      end
     end
 
     def thump

--- a/spec/specwrk/worker_spec.rb
+++ b/spec/specwrk/worker_spec.rb
@@ -231,6 +231,19 @@ RSpec.describe Specwrk::Worker do
       expect { instance.execute }.to change { instance.next_examples.object_id }
     end
 
+    it "passes the popped batch to complete_examples so unexecuted examples can be reported" do
+      batch = [{id: "a.rb:1"}, {id: "b.rb:2"}]
+      allow(client).to receive(:fetch_examples)
+        .and_return(batch)
+
+      expect(executor).to receive(:run)
+        .with(batch)
+      expect(instance).to receive(:complete_examples)
+        .with(batch)
+
+      instance.execute
+    end
+
     it "warns when an unhandled error is raised" do
       expect(client).to receive(:fetch_examples)
         .and_raise(Specwrk::UnhandledResponseError, "oops")
@@ -270,6 +283,58 @@ RSpec.describe Specwrk::Worker do
         .with(1)
 
       instance.complete_examples
+    end
+
+    it "reports batch examples the runner never executed as failed so they are not stranded on the server" do
+      allow(executor).to receive(:examples)
+        .and_return([{id: "a.rb:1", status: "passed"}])
+
+      batch = [{id: "a.rb:1", file_path: "a.rb"}, {id: "c.rb:3", file_path: "c.rb"}]
+
+      expect(client).to receive(:complete_and_fetch_examples) do |examples|
+        expect(examples.map { |example| example[:id] }).to eq(["a.rb:1", "c.rb:3"])
+        expect(examples.last[:status]).to eq("failed")
+        "next-batch"
+      end
+
+      instance.complete_examples(batch)
+
+      expect(instance.instance_variable_get(:@next_examples)).to eq("next-batch")
+    end
+  end
+
+  describe "#unexecuted_examples" do
+    before do
+      allow(executor).to receive(:examples)
+        .and_return([{id: "a.rb:1", status: "passed"}])
+    end
+
+    it "returns an empty array for a nil or empty batch" do
+      expect(instance.unexecuted_examples(nil)).to eq([])
+      expect(instance.unexecuted_examples([])).to eq([])
+    end
+
+    it "returns an empty array when every batch example produced a result" do
+      expect(instance.unexecuted_examples([{id: "a.rb:1", file_path: "a.rb"}])).to eq([])
+    end
+
+    it "synthesizes a failed result for each batch example the runner produced no result for" do
+      batch = [
+        {id: "a.rb:1", file_path: "a.rb"},
+        {id: "c.rb:3", file_path: "c.rb", line_number: 3}
+      ]
+
+      results = instance.unexecuted_examples(batch)
+
+      expect(results.length).to eq(1)
+
+      result = results.first
+      expect(result[:id]).to eq("c.rb:3")
+      expect(result[:status]).to eq("failed")
+      expect(result[:file_path]).to eq("c.rb")
+      expect(result[:line_number]).to eq(3)
+      expect(result[:run_time]).to eq(0.0)
+      expect(result.dig(:exception, :message)).to include("produced no result")
     end
   end
 


### PR DESCRIPTION
Sup @danielwestendorf 👋🏻  - I finally got around to trying specwrk! Works like a charm except for this one issue I bumped into. The following is AI written, but I stand behind it. You can see the issue demonstrated [here](https://github.com/benjaminwood/specwrk-hang-repro/actions/runs/29370205440/job/87211487472). Let me know what you think.

Thanks for building specwrk! 🎁

## Bug

If the RSpec runner aborts before executing any example in a batch — an error in a `before(:suite)` hook, a spec file that fails to load — `Executor#examples` is empty, so the worker sends an empty completion payload and moves on to fresh work. The examples it popped are now stranded:

- `complete_and_pop` only removes examples from `processing` when a completion names them (`web/endpoints/complete_and_pop.rb`).
- The expiry path only requeues work whose owner's heartbeat has gone stale (`web/endpoints/popable.rb`) — but the owner is alive, heartbeating, and working other batches.

`processing` never empties, so the run-complete condition (`completed.any? && processing.empty?` → 410) is never met, and every worker parks in `Worker#run`'s `rescue NoMoreExamplesError → sleep 0.5` loop (the `TODO` there already notes workers "hang until all work has been completed"). In CI this presents as the suite wedging until the job timeout with no output — the abort itself is buried in one worker's stream, so there's nothing to debug from.

Real-world trigger: 8 fresh CI workers raced a non-atomic check-then-create of a cluster-global Postgres role in `before(:suite)`. Losers raised `PG::UniqueViolation`, ran 0 examples in their first batch, and the run hung until the 10-minute kill.

Minimal repro (18 trivial examples, 2 workers, no Rails/DB), with a CI matrix showing bug / control / fix side by side: https://github.com/benjaminwood/specwrk-hang-repro. On v0.19.2 the bug job is killed by GitHub's 2-minute job timeout; on this branch the same run completes in ~3s.

## Fix

`Worker#execute` now passes the popped batch to `complete_examples`, which diffs it against `executor.examples` and synthesizes a `failed` result — with an exception naming the worker and the likely cause — for any example the runner produced no result for.

- The run finishes loudly instead of hanging; the failure points at suite setup / file load.
- `--max-retries` retries these like any other failure, which is the right behavior for transient setup races.
- No protocol or server changes; behavior is unchanged when every batch example produces a result.

An alternative (or complement) is a server-side guard: requeue `processing` entries owned by a worker that pops again, since a single-threaded worker asking for work can't still be running its previous batch. That would self-heal the same class of loss, but silently; the worker-side report was chosen because it surfaces the root cause rather than hiding it.

## Testing

- New specs for `#unexecuted_examples` and the batch pass-through in `#execute`/`#complete_examples`; suite green (219 examples, 0 failures), standardrb clean.
- E2E via the repro repo: hangs on v0.19.2, completes with the aborted examples reported as failed on this branch.
- CHANGELOG entry included under Unreleased.
