### PR TITLE
Don't hang when unreported examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased  
 [Compare](https://github.com/danielwestendorf/specwrk/compare/v0.19.2...main)  
+- Complete omitted worker processing examples as failures — [@danielwestendorf](https://github.com/danielwestendorf)  
 
 ## v0.19.2 — 2025-12-09  
 [Compare](https://github.com/danielwestendorf/specwrk/compare/v0.19.1...v0.19.2)  

--- a/lib/specwrk/web/endpoints/complete_and_pop.rb
+++ b/lib/specwrk/web/endpoints/complete_and_pop.rb
@@ -7,12 +7,14 @@ module Specwrk
     module Endpoints
       class CompleteAndPop < Popable
         EXAMPLE_STATUSES = %w[passed failed pending]
+        SYNTHETIC_FAILURE_CLASS = "Specwrk::WorkerExecutionError"
 
         def with_response
           retry_examples # pre-calculate before lock
+          omitted_processing_examples # pre-calculate before lock
 
           with_lock do
-            processing.delete(*(completed_examples.keys + retry_examples.keys))
+            processing.delete(*(completed_examples.keys + retry_examples.keys).map(&:to_s))
             pending.merge!(retry_examples)
           end
 
@@ -26,24 +28,30 @@ module Specwrk
 
         private
 
-        def all_examples
-          @all_examples ||= payload.map { |example| [example[:id], example] if processing_examples[example[:id]] }.compact.to_h
-        end
-
-        def processing_examples
-          @processing_examples ||= processing.multi_read(*payload.map { |example| example[:id] })
-        end
-
-        def completed_examples
-          @completed_examples ||= all_examples.map do |id, example|
-            next if retry_example?(example)
-
-            [id, example]
+        def reported_processing_examples
+          @reported_processing_examples ||= payload.map do |example|
+            [example[:id], example] if processing_examples_for_payload[example[:id]]
           end.compact.to_h
         end
 
+        def processing_examples_for_payload
+          @processing_examples_for_payload ||= processing.multi_read(*payload.map { |example| example[:id] })
+        end
+
+        def completed_examples
+          @completed_examples ||= begin
+            reported_completed_examples = reported_processing_examples.map do |id, example|
+              next if retry_example?(example)
+
+              [id, example]
+            end.compact.to_h
+
+            reported_completed_examples.merge(unreported_completed_examples)
+          end
+        end
+
         def retry_examples
-          @retry_examples ||= all_examples.map do |id, example|
+          @retry_examples ||= reported_processing_examples.map do |id, example|
             next unless retry_example?(example)
 
             [id, example]
@@ -66,7 +74,48 @@ module Specwrk
         end
 
         def all_example_failure_counts
-          @all_example_failure_counts ||= failure_counts.multi_read(*all_examples.keys)
+          @all_example_failure_counts ||= failure_counts.multi_read(*reported_processing_examples.keys)
+        end
+
+        def omitted_processing_examples
+          @omitted_processing_examples ||= processing.to_h.select do |_id, example|
+            example[:worker_id].to_s == worker_id && !payload_example_ids.include?(example[:id].to_s)
+          end
+        end
+
+        def unreported_completed_examples
+          @unreported_completed_examples ||= omitted_processing_examples.transform_values { |example| synthetic_failure_for(example) }
+        end
+
+        def payload_example_ids
+          @payload_example_ids ||= payload.map { |example| example[:id].to_s }.uniq
+        end
+
+        def synthetic_failure_for(example)
+          finished_at = Time.now
+
+          {
+            id: example[:id],
+            full_description: "Specwrk worker execution failed before completing #{example[:id]}",
+            status: "failed",
+            file_path: example[:file_path],
+            line_number: line_number_for(example),
+            started_at: finished_at.iso8601(6),
+            finished_at: finished_at.iso8601(6),
+            run_time: 0.0,
+            exception: {
+              class: SYNTHETIC_FAILURE_CLASS,
+              message: "Worker #{worker_id} claimed this example but did not submit a completion result. Check worker stderr/stdout for the underlying RSpec output.",
+              backtrace: []
+            }
+          }
+        end
+
+        def line_number_for(example)
+          return example[:line_number] if example[:line_number]
+
+          match = example[:id].to_s.match(/:(\d+)\z/)
+          match[1].to_i if match
         end
 
         def completed_examples_status_counts
@@ -87,7 +136,9 @@ module Specwrk
         end
 
         def run_time_data
-          @run_time_data ||= payload.map { |example| [example[:id], example[:run_time]] }.to_h
+          @run_time_data ||= payload.map { |example| [example[:id], example[:run_time]] }.to_h.merge(
+            unreported_completed_examples.transform_values { |example| example[:run_time] }
+          )
         end
       end
     end

--- a/spec/specwrk/web/endpoints/complete_and_pop_spec.rb
+++ b/spec/specwrk/web/endpoints/complete_and_pop_spec.rb
@@ -46,6 +46,57 @@ RSpec.describe Specwrk::Web::Endpoints::CompleteAndPop do
     it { expect { subject }.to change { processing.reload["a.rb:2"] }.from(nil).to({expected_run_time: 0.1, file_path: "a.rb", id: "a.rb:2", worker_id: "foobar-0", processing_started_at: instance_of(Integer)}) }
   end
 
+  context "when worker omits processing examples from the completion payload" do
+    let(:body) { JSON.generate([]) }
+    let(:existing_processing_data) do
+      {
+        "a.rb:1": {id: "a.rb:1", file_path: "a.rb", expected_run_time: 0.1, worker_id: worker_id, processing_started_at: Time.now.to_i},
+        "a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1, worker_id: worker_id, processing_started_at: Time.now.to_i}
+      }
+    end
+
+    it { is_expected.to eq([410, {"content-type" => "text/plain", "x-specwrk-status" => "2"}, ["That's a good lad. Run along now and go home."]]) }
+    it { expect { subject }.to change { processing.reload.length }.from(2).to(0) }
+    it { expect { subject }.to change { completed.reload.length }.from(0).to(2) }
+    it { expect { subject }.to change { worker["failed"] }.from(nil).to(2) }
+    it { expect { subject }.to change { run_times.reload.length }.from(0).to(2) }
+
+    it "records synthetic failures" do
+      subject
+
+      failure = completed.reload["a.rb:1"]
+      expect(failure).to include(
+        id: "a.rb:1",
+        file_path: "a.rb",
+        line_number: 1,
+        run_time: 0.0,
+        status: "failed"
+      )
+      expect(failure.dig(:exception, :class)).to eq("Specwrk::WorkerExecutionError")
+      expect(failure.dig(:exception, :message)).to include("did not submit a completion result")
+      expect(failure.dig(:exception, :backtrace)).to eq([])
+    end
+  end
+
+  context "when another worker also has processing examples" do
+    let(:body) { JSON.generate([]) }
+    let(:existing_processing_data) do
+      {
+        "a.rb:1": {id: "a.rb:1", file_path: "a.rb", expected_run_time: 0.1, worker_id: worker_id, processing_started_at: Time.now.to_i},
+        "a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1, worker_id: other_worker_id, processing_started_at: Time.now.to_i}
+      }
+    end
+
+    it "only completes the current worker's omitted examples" do
+      subject
+
+      expect(completed.reload["a.rb:1"]).to include(status: "failed")
+      expect(completed.reload["a.rb:2"]).to be_nil
+      expect(processing.reload["a.rb:1"]).to be_nil
+      expect(processing.reload["a.rb:2"]).to include(worker_id: other_worker_id)
+    end
+  end
+
   context "no items in the processing queue, but completed queue has items" do
     let(:existing_completed_data) do
       {"a.rb:2": {id: "a.rb:2", file_path: "a.rb", expected_run_time: 0.1}}

--- a/spec/specwrk/worker_spec.rb
+++ b/spec/specwrk/worker_spec.rb
@@ -9,17 +9,25 @@ RSpec.describe Specwrk::Worker do
 
   let(:instance) { described_class.new }
 
+  let(:executor_examples) { [{id: "a.rb:1"}, {id: "b.rb:2"}] }
+  let(:fetched_examples) do
+    [
+      {id: "a.rb:1", file_path: "a.rb"},
+      {id: "b.rb:2", file_path: "b.rb"}
+    ]
+  end
+
   let(:executor) do
     instance_double Specwrk::Worker::Executor,
       final_output: tempfile,
-      examples: %w[a.rb:1 b.rb:2]
+      examples: executor_examples
   end
 
   before do
     allow(Specwrk::Client).to receive(:new)
       .and_return(client)
 
-    allow(client).to receive(:fetch_examples) { %w[a.rb:1 b.rb:2].dup }
+    allow(client).to receive(:fetch_examples) { fetched_examples.map(&:dup) }
 
     allow(executor).to receive(:flush_log)
 
@@ -224,7 +232,7 @@ RSpec.describe Specwrk::Worker do
   describe "#execute" do
     it "tries fetching examples, executing them, and completing them" do
       expect(executor).to receive(:run)
-        .with(client.fetch_examples)
+        .with(fetched_examples)
 
       expect(instance).to receive(:complete_examples)
 


### PR DESCRIPTION
Fixes bug reported in #181 reported by @benjaminwood by tracking which examples have been popped by a worker but not submitted in the completed examples set.