### PR TITLE
Support parallel_tests-style TEST_ENV_NUMBER for forked workers

### DIFF
--- a/lib/specwrk/cli.rb
+++ b/lib/specwrk/cli.rb
@@ -67,7 +67,7 @@ module Specwrk
 
       def worker_env_for(idx)
         {
-          "TEST_ENV_NUMBER" => idx.to_s,
+          "TEST_ENV_NUMBER" => (idx == 1) ? "" : idx.to_s,
           "SPECWRK_FORKED" => idx.to_s,
           "SPECWRK_ID" => "#{ENV.fetch("SPECWRK_ID", "specwrk-worker")}-#{idx}"
         }

--- a/spec/specwrk/cli_worker_processes_spec.rb
+++ b/spec/specwrk/cli_worker_processes_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "specwrk/cli"
+
+RSpec.describe Specwrk::CLI::WorkerProcesses do
+  let(:instance) { Class.new { include Specwrk::CLI::WorkerProcesses }.new }
+
+  describe "#worker_env_for" do
+    it "leaves the first worker's TEST_ENV_NUMBER blank, parallel_tests-style" do
+      expect(instance.worker_env_for(1)).to include("TEST_ENV_NUMBER" => "")
+    end
+
+    it "numbers the remaining workers from 2" do
+      expect(instance.worker_env_for(2)).to include("TEST_ENV_NUMBER" => "2")
+      expect(instance.worker_env_for(3)).to include("TEST_ENV_NUMBER" => "3")
+    end
+  end
+end


### PR DESCRIPTION
Forked workers always set `TEST_ENV_NUMBER` to their 1-based index, so even a single worker looks for the `*_test1` database. Apps configured for the [parallel_tests](https://github.com/grosser/parallel_tests) gem use a different convention: the first worker's number is blank (`foo_test`, `foo_test2`, ...), so a single specwrk worker can't reuse the databases such an app already has.

This adjust the TEST_ENV_NUMBER values to use the same numbering scheme as `parallel_tests` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
