### PR TITLE
Add seed option for target bucket timing duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Options:
   --timeout=VALUE, -t VALUE         # The amount of time to wait for the server to respond. Overrides SPECWRK_TIMEOUT, default: "5"
   --network-retries=VALUE           # The number of times to retry in the event of a network failure. Overrides SPECWRK_NETWORK_RETRIES, default: "1"
   --max-retries=VALUE               # Number of times an example will be re-run should it fail, default: 0
+  --target-bucket-timing-duration=VALUE  # Target runtime duration per bucket in seconds, overriding the average timings calculation. Overrides SPECWRK_TARGET_BUCKET_TIMING_DURATION, default: "0"
   --help, -h                        # Print this help
 ```
 

--- a/lib/specwrk/cli.rb
+++ b/lib/specwrk/cli.rb
@@ -167,9 +167,10 @@ module Specwrk
 
       desc "Seed the server with a list of specs for the run"
       option :max_retries, default: 0, desc: "Number of times an example will be re-run should it fail"
+      option :target_bucket_timing_duration, default: ENV.fetch("SPECWRK_TARGET_BUCKET_TIMING_DURATION", "0"), desc: "Target runtime duration per bucket in seconds, overriding the average timings calculation. Overrides SPECWRK_TARGET_BUCKET_TIMING_DURATION"
       argument :dir, type: :array, required: false, desc: "Relative spec directory to run against, default: spec/"
 
-      def call(max_retries:, dir:, **args)
+      def call(max_retries:, dir:, target_bucket_timing_duration:, **args)
         dir = ["spec"] if dir.length.zero?
 
         self.class.setup(**args)
@@ -178,10 +179,12 @@ module Specwrk
         require "specwrk/client"
 
         ENV["SPECWRK_SEED"] = "1"
+        target_bucket_timing_duration = Float(target_bucket_timing_duration)
+        ENV["SPECWRK_TARGET_BUCKET_TIMING_DURATION"] = target_bucket_timing_duration.to_s
         examples = ListExamples.new(dir).examples
 
         Client.wait_for_server!
-        Client.new.seed(examples, max_retries)
+        Client.new.seed(examples, max_retries, target_bucket_timing_duration: target_bucket_timing_duration)
         file_count = examples.group_by { |e| e[:file_path] }.keys.size
         puts "🌱 Seeded #{examples.size} examples across #{file_count} files"
       rescue Errno::ECONNREFUSED

--- a/lib/specwrk/client.rb
+++ b/lib/specwrk/client.rb
@@ -119,8 +119,12 @@ module Specwrk
       end
     end
 
-    def seed(examples, max_retries)
-      response = post "/seed", body: {max_retries: max_retries, examples: examples}.to_json
+    def seed(examples, max_retries, target_bucket_timing_duration: 0)
+      response = post "/seed", body: {
+        max_retries: max_retries,
+        examples: examples,
+        target_bucket_timing_duration: target_bucket_timing_duration
+      }.to_json
 
       (response.code == "200") ? true : raise(UnhandledResponseError.new("#{response.code}: #{response.body}"))
     end

--- a/lib/specwrk/store/pending_store.rb
+++ b/lib/specwrk/store/pending_store.rb
@@ -19,6 +19,17 @@ module Specwrk
       @run_time_bucket_maximum ||= self[RUN_TIME_BUCKET_MAXIMUM_KEY]
     end
 
+    def update_run_time_bucket_maximum(calculated_run_time_bucket_maximum, target_bucket_timing_duration: 0)
+      target_bucket_timing_duration = target_bucket_timing_duration.to_f
+
+      if target_bucket_timing_duration.positive?
+        self.run_time_bucket_maximum = target_bucket_timing_duration
+      else
+        run_time_bucket_maximums = [run_time_bucket_maximum, calculated_run_time_bucket_maximum.to_f].compact
+        self.run_time_bucket_maximum = run_time_bucket_maximums.sum.to_f / run_time_bucket_maximums.length.to_f
+      end
+    end
+
     def max_retries=(val)
       @max_retries = self[MAX_RETRIES_KEY] = val
     end

--- a/lib/specwrk/web/endpoints/seed.rb
+++ b/lib/specwrk/web/endpoints/seed.rb
@@ -16,8 +16,10 @@ module Specwrk
 
           pending.max_retries = payload.fetch(:max_retries, "0").to_i
 
-          new_run_time_bucket_maximums = [pending.run_time_bucket_maximum, @seeds_run_time_bucket_maximum.to_f].compact
-          pending.run_time_bucket_maximum = new_run_time_bucket_maximums.sum.to_f / new_run_time_bucket_maximums.length.to_f
+          pending.update_run_time_bucket_maximum(
+            @seeds_run_time_bucket_maximum,
+            target_bucket_timing_duration: payload.fetch(:target_bucket_timing_duration, 0)
+          )
 
           with_lock do
             pending.merge!(examples_with_run_times)

--- a/spec/specwrk/cli_seed_spec.rb
+++ b/spec/specwrk/cli_seed_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "specwrk/cli"
+require "specwrk/client"
+require "specwrk/list_examples"
+
+RSpec.describe Specwrk::CLI::Seed do
+  subject(:call) do
+    command.call(
+      max_retries: 2,
+      dir: ["spec"],
+      target_bucket_timing_duration: target_bucket_timing_duration,
+      uri: "http://localhost:5138",
+      key: "",
+      run: "main",
+      timeout: "5",
+      network_retries: "1"
+    )
+  end
+
+  let(:command) { described_class.new }
+  let(:target_bucket_timing_duration) { "0" }
+  let(:examples) { [{id: "spec/a_spec.rb:1", file_path: "spec/a_spec.rb"}] }
+  let(:client) { instance_double(Specwrk::Client, seed: true) }
+
+  before do
+    stub_const("ENV", ENV.to_h)
+    allow(Specwrk::ListExamples).to receive(:new).with(["spec"]).and_return(instance_double(Specwrk::ListExamples, examples: examples))
+    allow(Specwrk::Client).to receive(:wait_for_server!)
+    allow(Specwrk::Client).to receive(:new).and_return(client)
+    allow(command).to receive(:puts)
+  end
+
+  it "sends zero when no target is given" do
+    expect(client).to receive(:seed).with(examples, 2, target_bucket_timing_duration: 0.0)
+
+    call
+
+    expect(ENV["SPECWRK_TARGET_BUCKET_TIMING_DURATION"]).to eq("0.0")
+  end
+
+  context "with a target bucket timing duration" do
+    let(:target_bucket_timing_duration) { "12.5" }
+
+    it "sends the duration to the client as a number" do
+      expect(client).to receive(:seed).with(examples, 2, target_bucket_timing_duration: 12.5)
+
+      call
+    end
+  end
+end

--- a/spec/specwrk/client_spec.rb
+++ b/spec/specwrk/client_spec.rb
@@ -348,11 +348,12 @@ RSpec.describe Specwrk::Client do
   end
 
   describe "#seed" do
-    subject { client.seed(examples, max_retries) }
+    subject { client.seed(examples, max_retries, **options) }
 
     let(:client) { described_class.new }
     let(:examples) { [{id: 1}] }
     let(:max_retries) { 5 }
+    let(:options) { {} }
 
     context "when response is 200" do
       before do
@@ -362,6 +363,24 @@ RSpec.describe Specwrk::Client do
       end
 
       it { is_expected.to be true }
+
+      it "sends zero as the default target bucket timing duration" do
+        subject
+
+        expect(WebMock).to have_requested(:post, "#{base_uri}/seed")
+          .with(body: {max_retries: 5, examples: examples, target_bucket_timing_duration: 0}.to_json)
+      end
+
+      context "with a target bucket timing duration" do
+        let(:options) { {target_bucket_timing_duration: 12.5} }
+
+        it "includes the duration in the seed payload" do
+          subject
+
+          expect(WebMock).to have_requested(:post, "#{base_uri}/seed")
+            .with(body: {max_retries: 5, examples: examples, target_bucket_timing_duration: 12.5}.to_json)
+        end
+      end
     end
 
     context "when response is error" do

--- a/spec/specwrk/store/pending_store_spec.rb
+++ b/spec/specwrk/store/pending_store_spec.rb
@@ -32,6 +32,33 @@ RSpec.describe Specwrk::PendingStore do
     it { is_expected.to eq(4) }
   end
 
+  describe "#update_run_time_bucket_maximum" do
+    subject do
+      instance.update_run_time_bucket_maximum(
+        4,
+        target_bucket_timing_duration: target_bucket_timing_duration
+      )
+    end
+
+    before { instance.run_time_bucket_maximum = 2 }
+
+    context "when the target bucket timing duration is zero" do
+      let(:target_bucket_timing_duration) { 0 }
+
+      it "uses the existing average timing behavior" do
+        expect { subject }.to change(instance, :run_time_bucket_maximum).from(2).to(3.0)
+      end
+    end
+
+    context "when the target bucket timing duration is positive" do
+      let(:target_bucket_timing_duration) { 10.5 }
+
+      it "overrides the calculated timing" do
+        expect { subject }.to change(instance, :run_time_bucket_maximum).from(2).to(10.5)
+      end
+    end
+  end
+
   describe "#max_retries=" do
     subject { instance.max_retries = 3 }
 

--- a/spec/specwrk/web/endpoints/seed_spec.rb
+++ b/spec/specwrk/web/endpoints/seed_spec.rb
@@ -69,6 +69,22 @@ RSpec.describe Specwrk::Web::Endpoints::Seed do
 
     it { expect { subject }.to change { pending.reload.run_time_bucket_maximum }.from(nil).to(0.7) }
 
+    context "with a target bucket timing duration" do
+      let(:body) do
+        JSON.generate(
+          target_bucket_timing_duration: 10.5,
+          examples: [
+            {id: "a.rb:1", file_path: "a.rb"},
+            {id: "a.rb:2", file_path: "a.rb"}
+          ]
+        )
+      end
+
+      it "uses the target instead of the calculated timing average" do
+        expect { subject }.to change { pending.reload.run_time_bucket_maximum }.from(nil).to(10.5)
+      end
+    end
+
     it "creates buckets grouped by expected run time" do
       subject
 


### PR DESCRIPTION
Each bucket will have up-to value's total runtime of specs