### PR TITLE
Lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Lifecycle hooks run synchronously in the process performing the corresponding wo
 | `Specwrk.after_seed(&blk)` | Runs after seeding examples to the server | `examples` RSpec examples |
 | `Specwrk.before_worker_fork(&blk)` | Runs in the parent process before spawning each worker | none |
 | `Specwrk.after_worker_fork(&blk)` | Runs in each worker process immediately after it is spawned | none |
+| `Specwrk.before_worker_examples_execute(&blk)` | Runs in a worker before an examples group is passed to the RSpec runner | `examples` RSpec examples in the group |
 
 ## Configuring your test environment
 If your test suite tracks state, starts servers, etc. and you plan on running many processes on the same node, you'll need to make

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Lifecycle hooks run synchronously in the process performing the corresponding wo
 | `Specwrk.before_seed(&blk)` | Runs before seeding examples to the server | none |
 | `Specwrk.after_seed(&blk)` | Runs after seeding examples to the server | `examples` RSpec examples |
 | `Specwrk.before_server_seed(&blk)` | Runs in the server before seeding examples | none |
+| `Specwrk.after_server_seed(&blk)` | Runs in the server after seeding examples | `examples` RSpec examples |
 | `Specwrk.before_worker_fork(&blk)` | Runs in the parent process before spawning each worker | none |
 | `Specwrk.after_worker_fork(&blk)` | Runs in each worker process immediately after it is spawned | none |
 | `Specwrk.before_worker_examples_execute(&blk)` | Runs in a worker before an examples group is passed to the RSpec runner | `examples` RSpec examples in the group |

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Lifecycle hooks run synchronously in the process performing the corresponding wo
 | `Specwrk.before_worker_examples_execute(&blk)` | Runs in a worker before an examples group is passed to the RSpec runner | `examples` RSpec examples in the group |
 | `Specwrk.after_worker_examples_execute(&blk)` | Runs in a worker after an examples group is executed by the RSpec runner | `examples` RSpec examples in the group |
 | `Specwrk.before_worker_exit(&blk)` | Runs in each worker after work completes and before the process exits | `status` Worker exit status |
+| `Specwrk.after_all_workers_exit(&blk)` | Runs in the parent process after all workers exit | `status` Overall worker exit status |
 
 ## Configuring your test environment
 If your test suite tracks state, starts servers, etc. and you plan on running many processes on the same node, you'll need to make

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Lifecycle hooks run synchronously in the process performing the corresponding wo
 | `Specwrk.before_worker_fork(&blk)` | Runs in the parent process before spawning each worker | none |
 | `Specwrk.after_worker_fork(&blk)` | Runs in each worker process immediately after it is spawned | none |
 | `Specwrk.before_worker_examples_execute(&blk)` | Runs in a worker before an examples group is passed to the RSpec runner | `examples` RSpec examples in the group |
+| `Specwrk.after_worker_examples_execute(&blk)` | Runs in a worker after an examples group is executed by the RSpec runner | `examples` RSpec examples in the group |
 
 ## Configuring your test environment
 If your test suite tracks state, starts servers, etc. and you plan on running many processes on the same node, you'll need to make

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Lifecycle hooks run synchronously in the process performing the corresponding wo
 | Hook Method | Description | Arguments |
 | --- | --- | --- |
 | `Specwrk.before_seed(&blk)` | Runs before seeding examples to the server | none |
+| `Specwrk.after_seed(&blk)` | Runs after seeding examples to the server | `examples` RSpec examples |
 
 ## Configuring your test environment
 If your test suite tracks state, starts servers, etc. and you plan on running many processes on the same node, you'll need to make

--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ Options:
   --help, -h                        # Print this help
 ```
 
+## Lifecycle hooks
+
+Lifecycle hooks run synchronously in the process performing the corresponding work.
+
+| Hook Method | Description | Arguments |
+| --- | --- | --- |
+| `Specwrk.before_seed(&blk)` | Runs before seeding examples to the server | none |
+
 ## Configuring your test environment
 If your test suite tracks state, starts servers, etc. and you plan on running many processes on the same node, you'll need to make
 adjustments to avoid conflicting port usage or database/state mutations.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Lifecycle hooks run synchronously in the process performing the corresponding wo
 | --- | --- | --- |
 | `Specwrk.before_seed(&blk)` | Runs before seeding examples to the server | none |
 | `Specwrk.after_seed(&blk)` | Runs after seeding examples to the server | `examples` RSpec examples |
+| `Specwrk.before_server_seed(&blk)` | Runs in the server before seeding examples | none |
 | `Specwrk.before_worker_fork(&blk)` | Runs in the parent process before spawning each worker | none |
 | `Specwrk.after_worker_fork(&blk)` | Runs in each worker process immediately after it is spawned | none |
 | `Specwrk.before_worker_examples_execute(&blk)` | Runs in a worker before an examples group is passed to the RSpec runner | `examples` RSpec examples in the group |

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Lifecycle hooks run synchronously in the process performing the corresponding wo
 | `Specwrk.after_worker_fork(&blk)` | Runs in each worker process immediately after it is spawned | none |
 | `Specwrk.before_worker_examples_execute(&blk)` | Runs in a worker before an examples group is passed to the RSpec runner | `examples` RSpec examples in the group |
 | `Specwrk.after_worker_examples_execute(&blk)` | Runs in a worker after an examples group is executed by the RSpec runner | `examples` RSpec examples in the group |
+| `Specwrk.before_worker_exit(&blk)` | Runs in each worker after work completes and before the process exits | `status` Worker exit status |
 
 ## Configuring your test environment
 If your test suite tracks state, starts servers, etc. and you plan on running many processes on the same node, you'll need to make

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ Options:
 
 ## Lifecycle hooks
 
-Lifecycle hooks run synchronously in the process performing the corresponding work. Hooks are process-local, so hooks that run in spawned child processes must be registered by code loaded in that child.
+Lifecycle hooks run synchronously in the process performing the corresponding work. Add hook registrations to `Specwrk.hooks.rb` in the directory where you run `specwrk`; the file is loaded automatically by the `seed`, `work`, `serve`, `start`, and `watch` commands. Use `--hooks=path/to/hooks.rb` to load a different file.
+
+The hooks file is ordinary Ruby and is loaded into the parent, server, seed, and worker processes as applicable. Hooks remain process-local and are not serialized between processes.
 
 | Hook Method | Description | Arguments |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Lifecycle hooks run synchronously in the process performing the corresponding wo
 | --- | --- | --- |
 | `Specwrk.before_seed(&blk)` | Runs before seeding examples to the server | none |
 | `Specwrk.after_seed(&blk)` | Runs after seeding examples to the server | `examples` RSpec examples |
+| `Specwrk.before_worker_fork(&blk)` | Runs in the parent process before spawning each worker | none |
 
 ## Configuring your test environment
 If your test suite tracks state, starts servers, etc. and you plan on running many processes on the same node, you'll need to make

--- a/README.md
+++ b/README.md
@@ -169,13 +169,14 @@ Options:
 
 ## Lifecycle hooks
 
-Lifecycle hooks run synchronously in the process performing the corresponding work.
+Lifecycle hooks run synchronously in the process performing the corresponding work. Hooks are process-local, so hooks that run in spawned child processes must be registered by code loaded in that child.
 
 | Hook Method | Description | Arguments |
 | --- | --- | --- |
 | `Specwrk.before_seed(&blk)` | Runs before seeding examples to the server | none |
 | `Specwrk.after_seed(&blk)` | Runs after seeding examples to the server | `examples` RSpec examples |
 | `Specwrk.before_worker_fork(&blk)` | Runs in the parent process before spawning each worker | none |
+| `Specwrk.after_worker_fork(&blk)` | Runs in each worker process immediately after it is spawned | none |
 
 ## Configuring your test environment
 If your test suite tracks state, starts servers, etc. and you plan on running many processes on the same node, you'll need to make

--- a/Specwrk.hooks.rb
+++ b/Specwrk.hooks.rb
@@ -1,0 +1,68 @@
+# specwrk_hook_log = lambda do |event, **details|
+#   specwrk_env = ENV.each_with_object({}) do |(name, value), values|
+#     next unless name.start_with?("SPECWRK_")
+#
+#     values[name] = if name.match?(/KEY|TOKEN|SECRET|PASSWORD/)
+#       "[REDACTED]"
+#     else
+#       value
+#     end
+#   end.sort.to_h
+#
+#   context = {
+#     event: event,
+#     pid: Process.pid,
+#     ppid: Process.ppid,
+#     specwrk_env: specwrk_env
+#   }.merge(details)
+#
+#   puts context.map { |name, value| "#{name}=#{value.inspect}" }.join(" ")
+# end
+#
+# Specwrk.before_seed do
+#   specwrk_hook_log.call("before_seed")
+# end
+#
+# Specwrk.after_seed do |examples|
+#   specwrk_hook_log.call("after_seed", example_count: examples.length)
+# end
+#
+# Specwrk.before_server_seed do
+#   specwrk_hook_log.call("before_server_seed")
+# end
+#
+# Specwrk.after_server_seed do |examples|
+#   specwrk_hook_log.call("after_server_seed", example_count: examples.length)
+# end
+#
+# Specwrk.before_worker_fork do
+#   specwrk_hook_log.call("before_worker_fork")
+# end
+#
+# Specwrk.after_worker_fork do
+#   specwrk_hook_log.call("after_worker_fork")
+# end
+#
+# Specwrk.before_worker_examples_execute do |examples|
+#   specwrk_hook_log.call(
+#     "before_worker_examples_execute",
+#     example_count: examples.length,
+#     example_ids: examples.map { |example| example[:id] }
+#   )
+# end
+#
+# Specwrk.after_worker_examples_execute do |examples|
+#   specwrk_hook_log.call(
+#     "after_worker_examples_execute",
+#     example_count: examples.length,
+#     example_ids: examples.map { |example| example[:id] }
+#   )
+# end
+#
+# Specwrk.before_worker_exit do |status|
+#   specwrk_hook_log.call("before_worker_exit", status: status)
+# end
+#
+# Specwrk.after_all_workers_exit do |status|
+#   specwrk_hook_log.call("after_all_workers_exit", status: status)
+# end

--- a/lib/specwrk.rb
+++ b/lib/specwrk.rb
@@ -28,6 +28,10 @@ module Specwrk
       Hooks.register(:after_seed, &block)
     end
 
+    def before_server_seed(&block)
+      Hooks.register(:before_server_seed, &block)
+    end
+
     def before_worker_fork(&block)
       Hooks.register(:before_worker_fork, &block)
     end

--- a/lib/specwrk.rb
+++ b/lib/specwrk.rb
@@ -44,6 +44,10 @@ module Specwrk
       Hooks.register(:after_worker_examples_execute, &block)
     end
 
+    def before_worker_exit(&block)
+      Hooks.register(:before_worker_exit, &block)
+    end
+
     def wait_for_pids_exit(pids)
       exited_pids = {}
 

--- a/lib/specwrk.rb
+++ b/lib/specwrk.rb
@@ -32,6 +32,10 @@ module Specwrk
       Hooks.register(:before_worker_fork, &block)
     end
 
+    def after_worker_fork(&block)
+      Hooks.register(:after_worker_fork, &block)
+    end
+
     def wait_for_pids_exit(pids)
       exited_pids = {}
 

--- a/lib/specwrk.rb
+++ b/lib/specwrk.rb
@@ -48,6 +48,10 @@ module Specwrk
       Hooks.register(:before_worker_exit, &block)
     end
 
+    def after_all_workers_exit(&block)
+      Hooks.register(:after_all_workers_exit, &block)
+    end
+
     def wait_for_pids_exit(pids)
       exited_pids = {}
 

--- a/lib/specwrk.rb
+++ b/lib/specwrk.rb
@@ -24,6 +24,10 @@ module Specwrk
       Hooks.register(:before_seed, &block)
     end
 
+    def after_seed(&block)
+      Hooks.register(:after_seed, &block)
+    end
+
     def wait_for_pids_exit(pids)
       exited_pids = {}
 

--- a/lib/specwrk.rb
+++ b/lib/specwrk.rb
@@ -28,6 +28,10 @@ module Specwrk
       Hooks.register(:after_seed, &block)
     end
 
+    def before_worker_fork(&block)
+      Hooks.register(:before_worker_fork, &block)
+    end
+
     def wait_for_pids_exit(pids)
       exited_pids = {}
 

--- a/lib/specwrk.rb
+++ b/lib/specwrk.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "specwrk/version"
+require "specwrk/hooks"
 
 module Specwrk
   Error = Class.new(StandardError)

--- a/lib/specwrk.rb
+++ b/lib/specwrk.rb
@@ -36,6 +36,10 @@ module Specwrk
       Hooks.register(:after_worker_fork, &block)
     end
 
+    def before_worker_examples_execute(&block)
+      Hooks.register(:before_worker_examples_execute, &block)
+    end
+
     def wait_for_pids_exit(pids)
       exited_pids = {}
 

--- a/lib/specwrk.rb
+++ b/lib/specwrk.rb
@@ -20,6 +20,10 @@ module Specwrk
     attr_accessor :force_quit, :net_http
     attr_reader :starting_pid
 
+    def before_seed(&block)
+      Hooks.register(:before_seed, &block)
+    end
+
     def wait_for_pids_exit(pids)
       exited_pids = {}
 

--- a/lib/specwrk.rb
+++ b/lib/specwrk.rb
@@ -32,6 +32,10 @@ module Specwrk
       Hooks.register(:before_server_seed, &block)
     end
 
+    def after_server_seed(&block)
+      Hooks.register(:after_server_seed, &block)
+    end
+
     def before_worker_fork(&block)
       Hooks.register(:before_worker_fork, &block)
     end

--- a/lib/specwrk.rb
+++ b/lib/specwrk.rb
@@ -40,6 +40,10 @@ module Specwrk
       Hooks.register(:before_worker_examples_execute, &block)
     end
 
+    def after_worker_examples_execute(&block)
+      Hooks.register(:after_worker_examples_execute, &block)
+    end
+
     def wait_for_pids_exit(pids)
       exited_pids = {}
 

--- a/lib/specwrk/cli.rb
+++ b/lib/specwrk/cli.rb
@@ -16,6 +16,9 @@ module Specwrk
 
     module WorkerProcesses
       WORKER_INIT_SCRIPT = <<~RUBY
+        require "specwrk"
+        Specwrk::Hooks.run(:after_worker_fork)
+
         writer = IO.for_fd(Integer(ENV.fetch("SPECWRK_FINAL_FD")))
         $final_output = writer # standard:disable Style/GlobalVars
         $final_output.sync = true # standard:disable Style/GlobalVars

--- a/lib/specwrk/cli.rb
+++ b/lib/specwrk/cli.rb
@@ -221,7 +221,10 @@ module Specwrk
       end
 
       def wait_for_workers_exit
-        @exited_pids = Specwrk.wait_for_pids_exit(@worker_pids)
+        Specwrk.wait_for_pids_exit(@worker_pids).tap do |exited_pids|
+          @exited_pids = exited_pids
+          Hooks.run(:after_all_workers_exit, status)
+        end
       end
 
       def status

--- a/lib/specwrk/cli.rb
+++ b/lib/specwrk/cli.rb
@@ -34,6 +34,7 @@ module Specwrk
         end
 
         status = Specwrk::Worker.run!
+        Specwrk::Hooks.run(:before_worker_exit, status)
         $final_output.close # standard:disable Style/GlobalVars
         exit(status)
       RUBY

--- a/lib/specwrk/cli.rb
+++ b/lib/specwrk/cli.rb
@@ -45,6 +45,7 @@ module Specwrk
             "SPECWRK_FINAL_FD" => writer.fileno.to_s
           )
 
+          Hooks.run(:before_worker_fork)
           Process.spawn(
             env, RbConfig.ruby, "-e", WORKER_INIT_SCRIPT,
             writer.fileno => writer,

--- a/lib/specwrk/cli.rb
+++ b/lib/specwrk/cli.rb
@@ -14,9 +14,24 @@ module Specwrk
   module CLI
     extend Dry::CLI::Registry
 
+    module HooksConfigurable
+      extend Hookable
+
+      on_included do |base|
+        base.unique_option :hooks, type: :string, default: "Specwrk.hooks.rb", desc: "Path to lifecycle hooks configuration"
+      end
+
+      on_setup do |hooks: "Specwrk.hooks.rb", **|
+        hooks_file = Pathname.new(hooks).expand_path(Dir.pwd).to_s
+        ENV["SPECWRK_HOOKS_FILE"] = hooks_file
+        Hooks.load_file(hooks_file)
+      end
+    end
+
     module WorkerProcesses
       WORKER_INIT_SCRIPT = <<~RUBY
         require "specwrk"
+        Specwrk::Hooks.load_file(ENV["SPECWRK_HOOKS_FILE"])
         Specwrk::Hooks.run(:after_worker_fork)
 
         writer = IO.for_fd(Integer(ENV.fetch("SPECWRK_FINAL_FD")))
@@ -169,6 +184,7 @@ module Specwrk
 
     class Seed < Dry::CLI::Command
       include Clientable
+      include HooksConfigurable
 
       desc "Seed the server with a list of specs for the run"
       option :max_retries, default: 0, desc: "Number of times an example will be re-run should it fail"
@@ -204,6 +220,7 @@ module Specwrk
     class Work < Dry::CLI::Command
       include Workable
       include Clientable
+      include HooksConfigurable
 
       desc "Start one or more worker processes"
 
@@ -234,6 +251,7 @@ module Specwrk
 
     class Serve < Dry::CLI::Command
       include Servable
+      include HooksConfigurable
 
       desc "Start a queue server"
       option :single_run, type: :boolean, default: false, desc: "Act on shutdown requests from clients"
@@ -254,9 +272,12 @@ module Specwrk
       include Clientable
       include Workable
       include Servable
+      include HooksConfigurable
 
       SEED_INIT_SCRIPT = <<~'RUBY'
         require "json"
+        require "specwrk"
+        Specwrk::Hooks.load_file(ENV["SPECWRK_HOOKS_FILE"])
         require "specwrk/list_examples"
         require "specwrk/client"
 
@@ -355,8 +376,11 @@ module Specwrk
     class Watch < Dry::CLI::Command
       include WorkerProcesses
       include PortDiscoverable
+      include HooksConfigurable
 
       SEED_LOOP_INIT_SCRIPT = <<~RUBY
+        require "specwrk"
+        Specwrk::Hooks.load_file(ENV["SPECWRK_HOOKS_FILE"])
         require "specwrk/ipc"
         require "specwrk/seed_loop"
 
@@ -385,6 +409,8 @@ module Specwrk
         ENV["SPECWRK_MAX_BUCKET_SIZE"] = "1"
         ENV["SPECWRK_COUNT"] = count.to_s
         ENV["SPECWRK_RUN"] = "watch"
+
+        self.class.setup(**args)
 
         web_pid
 

--- a/lib/specwrk/hooks.rb
+++ b/lib/specwrk/hooks.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Specwrk
+  module Hooks
+    class << self
+      def register(name, &block)
+        raise ArgumentError, "a block is required" unless block
+
+        hooks[name] << block
+        block
+      end
+
+      def run(name, *objects)
+        hooks.fetch(name, []).dup.each { |hook| hook.call(*objects) }
+        nil
+      end
+
+      def reset!
+        @hooks = nil
+      end
+
+      private
+
+      def hooks
+        @hooks ||= Hash.new { |registry, name| registry[name] = [] }
+      end
+    end
+  end
+end

--- a/lib/specwrk/hooks.rb
+++ b/lib/specwrk/hooks.rb
@@ -15,6 +15,10 @@ module Specwrk
         nil
       end
 
+      def load_file(file)
+        Kernel.load(file) if file && File.file?(file)
+      end
+
       def reset!
         @hooks = nil
       end

--- a/lib/specwrk/seed_loop.rb
+++ b/lib/specwrk/seed_loop.rb
@@ -6,6 +6,7 @@ require "specwrk/client"
 module Specwrk
   class SeedLoop
     def self.loop!(ipc)
+      Hooks.run(:before_seed)
       Client.wait_for_server!
 
       loop do

--- a/lib/specwrk/seed_loop.rb
+++ b/lib/specwrk/seed_loop.rb
@@ -19,6 +19,7 @@ module Specwrk
 
         client = Client.new
         client.seed(examples, 0)
+        Hooks.run(:after_seed, examples)
         client.close
 
         ipc.write examples.length

--- a/lib/specwrk/web/endpoints/seed.rb
+++ b/lib/specwrk/web/endpoints/seed.rb
@@ -7,6 +7,7 @@ module Specwrk
     module Endpoints
       class Seed < Base
         def with_response
+          Hooks.run(:before_server_seed)
           examples_with_run_times
 
           pending.clear

--- a/lib/specwrk/web/endpoints/seed.rb
+++ b/lib/specwrk/web/endpoints/seed.rb
@@ -26,6 +26,7 @@ module Specwrk
             pending.merge!(examples_with_run_times)
           end
 
+          Hooks.run(:after_server_seed, payload[:examples])
           ok
         end
 

--- a/lib/specwrk/worker/executor.rb
+++ b/lib/specwrk/worker/executor.rb
@@ -25,6 +25,7 @@ module Specwrk
         example_ids = examples.map { |example| example[:id] }
 
         options = RSpec::Core::ConfigurationOptions.new ["--format", "Specwrk::Worker::NullFormatter"] + example_ids
+        Hooks.run(:before_worker_examples_execute, examples)
         RSpec::Core::Runner.new(options).run($stderr, $stdout)
       end
 

--- a/lib/specwrk/worker/executor.rb
+++ b/lib/specwrk/worker/executor.rb
@@ -26,7 +26,9 @@ module Specwrk
 
         options = RSpec::Core::ConfigurationOptions.new ["--format", "Specwrk::Worker::NullFormatter"] + example_ids
         Hooks.run(:before_worker_examples_execute, examples)
-        RSpec::Core::Runner.new(options).run($stderr, $stdout)
+        RSpec::Core::Runner.new(options).run($stderr, $stdout).tap do
+          Hooks.run(:after_worker_examples_execute, examples)
+        end
       end
 
       # https://github.com/skroutz/rspecq/blob/341383ce3ca25f42fad5483cbb6a00ba1c405570/lib/rspecq/worker.rb#L208-L224

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,8 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
+  config.before(:each) { Specwrk::Hooks.reset! }
+
   if ENV["TEST_ENV_NUMBER"]
     config.before(:each) { sleep 0.25 }
   end

--- a/spec/specwrk/cli_hooks_configurable_spec.rb
+++ b/spec/specwrk/cli_hooks_configurable_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+require "specwrk/cli"
+
+RSpec.describe Specwrk::CLI::HooksConfigurable do
+  let(:command_class) do
+    Class.new(Dry::CLI::Command) do
+      include Specwrk::CLI::HooksConfigurable
+    end
+  end
+
+  before do
+    stub_const("ENV", ENV.to_h)
+  end
+
+  it "adds a hooks option with Specwrk.hooks.rb as the default" do
+    option = command_class.options.find { |candidate| candidate.name == :hooks }
+
+    expect(option.default).to eq("Specwrk.hooks.rb")
+  end
+
+  it "loads an overridden hooks file and exposes its absolute path to child processes" do
+    Dir.mktmpdir("specwrk-hooks") do |dir|
+      file = File.join(dir, "custom-hooks.rb")
+      File.write(file, <<~RUBY)
+        Specwrk::Hooks.register(:configured_hook) { |calls| calls << :configured }
+      RUBY
+      calls = []
+
+      Dir.chdir(dir) { command_class.setup(hooks: "custom-hooks.rb") }
+      Specwrk::Hooks.run(:configured_hook, calls)
+
+      expect(calls).to eq([:configured])
+      expect(ENV["SPECWRK_HOOKS_FILE"]).to eq(File.realpath(file))
+    end
+  end
+
+  it "is available on every lifecycle command" do
+    command_classes = [
+      Specwrk::CLI::Seed,
+      Specwrk::CLI::Work,
+      Specwrk::CLI::Serve,
+      Specwrk::CLI::Start,
+      Specwrk::CLI::Watch
+    ]
+
+    expect(command_classes).to all(satisfy do |klass|
+      klass.options.any? { |option| option.name == :hooks }
+    end)
+  end
+end

--- a/spec/specwrk/cli_worker_processes_spec.rb
+++ b/spec/specwrk/cli_worker_processes_spec.rb
@@ -7,20 +7,24 @@ require "specwrk/cli"
 RSpec.describe Specwrk::CLI::WorkerProcesses do
   let(:instance) { Class.new { include Specwrk::CLI::WorkerProcesses }.new }
 
-  def run_worker_with(setup_source)
+  def run_worker_with(setup_source, hooks_source: nil)
     Dir.mktmpdir("worker_hooks") do |dir|
       setup_path = File.join(dir, "setup.rb")
+      hooks_path = File.join(dir, "hooks.rb")
       output_path = File.join(dir, "output")
       File.write(setup_path, setup_source)
+      File.write(hooks_path, hooks_source) if hooks_source
 
       reader, writer = IO.pipe
       rubyopt = [ENV["RUBYOPT"], "-r#{setup_path}"].compact.join(" ")
+      env = {
+        "RUBYOPT" => rubyopt,
+        "SPECWRK_FINAL_FD" => writer.fileno.to_s,
+        "WORKER_HOOK_OUTPUT" => output_path
+      }
+      env["SPECWRK_HOOKS_FILE"] = hooks_path if hooks_source
       pid = Process.spawn(
-        {
-          "RUBYOPT" => rubyopt,
-          "SPECWRK_FINAL_FD" => writer.fileno.to_s,
-          "WORKER_HOOK_OUTPUT" => output_path
-        },
+        env,
         RbConfig.ruby,
         "-I", File.expand_path("../../lib", __dir__),
         "-e", described_class::WORKER_INIT_SCRIPT,
@@ -79,6 +83,23 @@ RSpec.describe Specwrk::CLI::WorkerProcesses do
       expect(result[:status]).to be_success
       expect(result[:output]).to eq(result[:pid].to_s)
       expect(result[:pid]).not_to eq(parent_pid)
+    end
+
+    it "loads hooks from the configured file inside the spawned child process" do
+      result = run_worker_with(
+        <<~RUBY,
+          require "specwrk"
+        RUBY
+        hooks_source: <<~RUBY
+          Specwrk.after_worker_fork do
+            File.write(ENV.fetch("WORKER_HOOK_OUTPUT"), Process.pid)
+            exit(0)
+          end
+        RUBY
+      )
+
+      expect(result[:status]).to be_success
+      expect(result[:output]).to eq(result[:pid].to_s)
     end
 
     it "runs before_worker_exit inside the worker after work completes" do

--- a/spec/specwrk/cli_worker_processes_spec.rb
+++ b/spec/specwrk/cli_worker_processes_spec.rb
@@ -5,6 +5,35 @@ require "specwrk/cli"
 RSpec.describe Specwrk::CLI::WorkerProcesses do
   let(:instance) { Class.new { include Specwrk::CLI::WorkerProcesses }.new }
 
+  describe "#start_workers" do
+    it "runs before_worker_fork in the parent before each worker spawn" do
+      parent_pid = Process.pid
+      calls = []
+      readers = Array.new(2) { instance_double(IO) }
+      writers = Array.new(2) { instance_double(IO, fileno: 42, close: nil) }
+
+      allow(instance).to receive(:worker_count).and_return(2)
+      allow(IO).to receive(:pipe).and_return(
+        [readers[0], writers[0]],
+        [readers[1], writers[1]]
+      )
+      allow(Process).to receive(:spawn) do
+        calls << [:spawn, Process.pid]
+        123
+      end
+      Specwrk.before_worker_fork { calls << [:hook, Process.pid] }
+
+      instance.start_workers
+
+      expect(calls).to eq([
+        [:hook, parent_pid],
+        [:spawn, parent_pid],
+        [:hook, parent_pid],
+        [:spawn, parent_pid]
+      ])
+    end
+  end
+
   describe "#worker_env_for" do
     it "leaves the first worker's TEST_ENV_NUMBER blank, parallel_tests-style" do
       expect(instance.worker_env_for(1)).to include("TEST_ENV_NUMBER" => "")

--- a/spec/specwrk/cli_worker_processes_spec.rb
+++ b/spec/specwrk/cli_worker_processes_spec.rb
@@ -1,11 +1,41 @@
 # frozen_string_literal: true
 
-require "tempfile"
+require "tmpdir"
 
 require "specwrk/cli"
 
 RSpec.describe Specwrk::CLI::WorkerProcesses do
   let(:instance) { Class.new { include Specwrk::CLI::WorkerProcesses }.new }
+
+  def run_worker_with(setup_source)
+    Dir.mktmpdir("worker_hooks") do |dir|
+      setup_path = File.join(dir, "setup.rb")
+      output_path = File.join(dir, "output")
+      File.write(setup_path, setup_source)
+
+      reader, writer = IO.pipe
+      rubyopt = [ENV["RUBYOPT"], "-r#{setup_path}"].compact.join(" ")
+      pid = Process.spawn(
+        {
+          "RUBYOPT" => rubyopt,
+          "SPECWRK_FINAL_FD" => writer.fileno.to_s,
+          "WORKER_HOOK_OUTPUT" => output_path
+        },
+        RbConfig.ruby,
+        "-I", File.expand_path("../../lib", __dir__),
+        "-e", described_class::WORKER_INIT_SCRIPT,
+        writer.fileno => writer,
+        :err => File::NULL,
+        :close_others => false
+      )
+      writer.close
+
+      _, status = Process.wait2(pid)
+      reader.close
+
+      {pid: pid, status: status, output: File.read(output_path)}
+    end
+  end
 
   describe "#start_workers" do
     it "runs before_worker_fork in the parent before each worker spawn" do
@@ -37,45 +67,42 @@ RSpec.describe Specwrk::CLI::WorkerProcesses do
 
     it "runs after_worker_fork inside the spawned child process" do
       parent_pid = Process.pid
+      result = run_worker_with <<~RUBY
+        require "specwrk"
 
-      Tempfile.create(["after_worker_fork", ".rb"]) do |setup|
-        Tempfile.create("after_worker_fork_output") do |output|
-          setup.write <<~RUBY
-            require "specwrk"
-
-            Specwrk.after_worker_fork do
-              File.write(ENV.fetch("AFTER_WORKER_FORK_OUTPUT"), Process.pid)
-              exit(0)
-            end
-          RUBY
-          setup.flush
-
-          reader, writer = IO.pipe
-          rubyopt = [ENV["RUBYOPT"], "-r#{setup.path}"].compact.join(" ")
-          pid = Process.spawn(
-            {
-              "AFTER_WORKER_FORK_OUTPUT" => output.path,
-              "RUBYOPT" => rubyopt,
-              "SPECWRK_FINAL_FD" => writer.fileno.to_s
-            },
-            RbConfig.ruby,
-            "-I", File.expand_path("../../lib", __dir__),
-            "-e", described_class::WORKER_INIT_SCRIPT,
-            writer.fileno => writer,
-            :err => File::NULL,
-            :close_others => false
-          )
-          writer.close
-
-          _, status = Process.wait2(pid)
-          reader.close
-          output.rewind
-
-          expect(status).to be_success
-          expect(output.read).to eq(pid.to_s)
-          expect(pid).not_to eq(parent_pid)
+        Specwrk.after_worker_fork do
+          File.write(ENV.fetch("WORKER_HOOK_OUTPUT"), Process.pid)
+          exit(0)
         end
-      end
+      RUBY
+
+      expect(result[:status]).to be_success
+      expect(result[:output]).to eq(result[:pid].to_s)
+      expect(result[:pid]).not_to eq(parent_pid)
+    end
+
+    it "runs before_worker_exit inside the worker after work completes" do
+      result = run_worker_with <<~RUBY
+        require "specwrk"
+        require "specwrk/worker"
+
+        Specwrk::Worker.define_singleton_method(:run!) do
+          File.write(ENV.fetch("WORKER_HOOK_OUTPUT"), "run")
+          0
+        end
+
+        Specwrk.before_worker_exit do |status|
+          File.open(ENV.fetch("WORKER_HOOK_OUTPUT"), "a") do |file|
+            file.write(":hook:")
+            file.write(status)
+            file.write(":")
+            file.write(Process.pid)
+          end
+        end
+      RUBY
+
+      expect(result[:status]).to be_success
+      expect(result[:output]).to eq("run:hook:0:#{result[:pid]}")
     end
   end
 

--- a/spec/specwrk/cli_worker_processes_spec.rb
+++ b/spec/specwrk/cli_worker_processes_spec.rb
@@ -117,3 +117,20 @@ RSpec.describe Specwrk::CLI::WorkerProcesses do
     end
   end
 end
+
+RSpec.describe Specwrk::CLI::Work do
+  describe "#wait_for_workers_exit" do
+    it "runs after_all_workers_exit with the status after all workers exit" do
+      instance = described_class.new
+      worker_pids = [123, 456]
+      exited_pids = {123 => 0, 456 => 1}
+      instance.instance_variable_set(:@worker_pids, worker_pids)
+      allow(Specwrk).to receive(:wait_for_pids_exit).with(worker_pids).and_return(exited_pids)
+      received = nil
+      Specwrk.after_all_workers_exit { |status| received = status }
+
+      expect(instance.wait_for_workers_exit).to be(exited_pids)
+      expect(received).to eq(instance.status)
+    end
+  end
+end

--- a/spec/specwrk/cli_worker_processes_spec.rb
+++ b/spec/specwrk/cli_worker_processes_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "tempfile"
+
 require "specwrk/cli"
 
 RSpec.describe Specwrk::CLI::WorkerProcesses do
@@ -31,6 +33,49 @@ RSpec.describe Specwrk::CLI::WorkerProcesses do
         [:hook, parent_pid],
         [:spawn, parent_pid]
       ])
+    end
+
+    it "runs after_worker_fork inside the spawned child process" do
+      parent_pid = Process.pid
+
+      Tempfile.create(["after_worker_fork", ".rb"]) do |setup|
+        Tempfile.create("after_worker_fork_output") do |output|
+          setup.write <<~RUBY
+            require "specwrk"
+
+            Specwrk.after_worker_fork do
+              File.write(ENV.fetch("AFTER_WORKER_FORK_OUTPUT"), Process.pid)
+              exit(0)
+            end
+          RUBY
+          setup.flush
+
+          reader, writer = IO.pipe
+          rubyopt = [ENV["RUBYOPT"], "-r#{setup.path}"].compact.join(" ")
+          pid = Process.spawn(
+            {
+              "AFTER_WORKER_FORK_OUTPUT" => output.path,
+              "RUBYOPT" => rubyopt,
+              "SPECWRK_FINAL_FD" => writer.fileno.to_s
+            },
+            RbConfig.ruby,
+            "-I", File.expand_path("../../lib", __dir__),
+            "-e", described_class::WORKER_INIT_SCRIPT,
+            writer.fileno => writer,
+            :err => File::NULL,
+            :close_others => false
+          )
+          writer.close
+
+          _, status = Process.wait2(pid)
+          reader.close
+          output.rewind
+
+          expect(status).to be_success
+          expect(output.read).to eq(pid.to_s)
+          expect(pid).not_to eq(parent_pid)
+        end
+      end
     end
   end
 

--- a/spec/specwrk/hooks_spec.rb
+++ b/spec/specwrk/hooks_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+RSpec.describe Specwrk::Hooks do
+  before { described_class.reset! }
+
+  describe ".register" do
+    it "registers multiple hooks under a name in order" do
+      calls = []
+
+      described_class.register(:before_work) { calls << :first }
+      described_class.register(:before_work) { calls << :second }
+
+      described_class.run(:before_work)
+
+      expect(calls).to eq([:first, :second])
+    end
+
+    it "returns the registered block" do
+      hook = proc {}
+
+      expect(described_class.register(:before_work, &hook)).to be(hook)
+    end
+
+    it "requires a block" do
+      expect { described_class.register(:before_work) }
+        .to raise_error(ArgumentError, "a block is required")
+    end
+  end
+
+  describe ".run" do
+    it "does nothing for an unregistered name" do
+      expect(described_class.run(:unregistered)).to be_nil
+    end
+
+    it "forwards zero positional objects" do
+      received = :not_called
+      described_class.register(:before_work) { |*objects| received = objects }
+
+      described_class.run(:before_work)
+
+      expect(received).to eq([])
+    end
+
+    it "forwards one positional object by identity" do
+      object = Object.new
+      received = nil
+      described_class.register(:before_work) { |value| received = value }
+
+      described_class.run(:before_work, object)
+
+      expect(received).to be(object)
+    end
+
+    it "forwards multiple positional objects by identity" do
+      first = Object.new
+      second = Object.new
+      received = nil
+      described_class.register(:before_work) { |*objects| received = objects }
+
+      described_class.run(:before_work, first, second)
+
+      expect(received[0]).to be(first)
+      expect(received[1]).to be(second)
+    end
+
+    it "ignores hook return values and returns nil" do
+      described_class.register(:before_work) { :hook_result }
+
+      expect(described_class.run(:before_work)).to be_nil
+    end
+
+    it "propagates the first exception and skips remaining hooks" do
+      calls = []
+      error = Class.new(StandardError)
+      described_class.register(:before_work) do
+        calls << :first
+        raise error, "hook failed"
+      end
+      described_class.register(:before_work) { calls << :second }
+
+      expect { described_class.run(:before_work) }
+        .to raise_error(error, "hook failed")
+      expect(calls).to eq([:first])
+    end
+
+    it "does not run hooks registered during execution until the next run" do
+      calls = []
+      added = false
+      described_class.register(:before_work) do
+        calls << :first
+        next if added
+
+        added = true
+        described_class.register(:before_work) { calls << :added }
+      end
+
+      described_class.run(:before_work)
+      expect(calls).to eq([:first])
+
+      described_class.run(:before_work)
+      expect(calls).to eq([:first, :first, :added])
+    end
+  end
+
+  describe ".reset!" do
+    it "clears registered hooks" do
+      calls = []
+      described_class.register(:before_work) { calls << :called }
+
+      described_class.reset!
+      described_class.run(:before_work)
+
+      expect(calls).to be_empty
+    end
+  end
+end

--- a/spec/specwrk/hooks_spec.rb
+++ b/spec/specwrk/hooks_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "tmpdir"
+
 RSpec.describe Specwrk::Hooks do
   describe ".register" do
     it "registers multiple hooks under a name in order" do
@@ -109,6 +111,27 @@ RSpec.describe Specwrk::Hooks do
       described_class.run(:before_work)
 
       expect(calls).to be_empty
+    end
+  end
+
+  describe ".load_file" do
+    it "loads hook registrations from an existing Ruby file" do
+      Dir.mktmpdir("specwrk-hooks") do |dir|
+        file = File.join(dir, "hooks.rb")
+        File.write(file, <<~RUBY)
+          Specwrk::Hooks.register(:loaded_from_file) { |calls| calls << :loaded }
+        RUBY
+        calls = []
+
+        described_class.load_file(file)
+        described_class.run(:loaded_from_file, calls)
+
+        expect(calls).to eq([:loaded])
+      end
+    end
+
+    it "ignores a missing file" do
+      expect(described_class.load_file("missing-hooks.rb")).to be_nil
     end
   end
 end

--- a/spec/specwrk/hooks_spec.rb
+++ b/spec/specwrk/hooks_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Specwrk::Hooks do
-  before { described_class.reset! }
-
   describe ".register" do
     it "registers multiple hooks under a name in order" do
       calls = []

--- a/spec/specwrk/seed_loop_spec.rb
+++ b/spec/specwrk/seed_loop_spec.rb
@@ -49,6 +49,26 @@ RSpec.describe Specwrk::SeedLoop do
 
         described_class.loop!(ipc)
       end
+
+      it "runs after_seed hooks after seeding and yields the examples" do
+        calls = []
+        allow(client_dbl).to receive(:seed) { calls << :seed }
+        Specwrk.after_seed { |hook_examples| calls << [:after_seed, hook_examples] }
+
+        described_class.loop!(ipc)
+
+        expect(calls[0]).to eq(:seed)
+        expect(calls[1][0]).to eq(:after_seed)
+        expect(calls[1][1]).to be(examples)
+      end
+
+      it "does not run after_seed hooks when seeding fails" do
+        Specwrk.after_seed { raise "hook ran" }
+        allow(client_dbl).to receive(:seed).and_raise(Specwrk::Error, "seed failed")
+
+        expect { described_class.loop!(ipc) }
+          .to raise_error(Specwrk::Error, "seed failed")
+      end
     end
 
     context "when ipc.read returns nil first" do

--- a/spec/specwrk/seed_loop_spec.rb
+++ b/spec/specwrk/seed_loop_spec.rb
@@ -22,6 +22,17 @@ RSpec.describe Specwrk::SeedLoop do
         .and_return(list_examples_dbl)
     end
 
+    it "runs before_seed hooks before starting the loop" do
+      calls = []
+      Specwrk.before_seed { calls << :before_seed }
+      allow(Specwrk::Client).to receive(:wait_for_server!) { calls << :wait_for_server }
+      allow(Specwrk).to receive(:force_quit).and_return(true)
+
+      described_class.loop!(ipc)
+
+      expect(calls).to eq([:before_seed, :wait_for_server])
+    end
+
     context "with a single batch of files" do
       before do
         allow(Specwrk).to receive(:force_quit).and_return(false, true) # run once, then break

--- a/spec/specwrk/web/endpoints/seed_spec.rb
+++ b/spec/specwrk/web/endpoints/seed_spec.rb
@@ -21,6 +21,20 @@ RSpec.describe Specwrk::Web::Endpoints::Seed do
     expect(processing.reload).to be_empty
   end
 
+  it "runs after_server_seed after storing and yields the examples" do
+    received_examples = nil
+    pending_length_seen_by_hook = nil
+    Specwrk.after_server_seed do |examples|
+      received_examples = examples
+      pending_length_seen_by_hook = pending.reload.length
+    end
+
+    subject
+
+    expect(received_examples.map { |example| example[:id] }).to eq(["a.rb:1"])
+    expect(pending_length_seen_by_hook).to eq(1)
+  end
+
   context "pending store reset with examples and meta data" do
     let(:existing_pending_data) { {"b.rb:2" => {id: "b.rb:2", file_path: "b.rb", expected_run_time: 0.1}} }
 

--- a/spec/specwrk/web/endpoints/seed_spec.rb
+++ b/spec/specwrk/web/endpoints/seed_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe Specwrk::Web::Endpoints::Seed do
   let(:request_method) { "POST" }
   let(:body) { JSON.generate(max_retries: 42, examples: [{id: "a.rb:1", file_path: "a.rb", run_time: 0.1}]) }
 
+  it "runs before_server_seed before resetting server state" do
+    existing_processing_data = {"existing.rb:1": {id: "existing.rb:1"}}
+    processing.merge!(existing_processing_data)
+    processing_seen_by_hook = nil
+    Specwrk.before_server_seed { processing_seen_by_hook = processing.reload.to_h }
+
+    subject
+
+    expect(processing_seen_by_hook.keys).to eq([:"existing.rb:1"])
+    expect(processing.reload).to be_empty
+  end
+
   context "pending store reset with examples and meta data" do
     let(:existing_pending_data) { {"b.rb:2" => {id: "b.rb:2", file_path: "b.rb", expected_run_time: 0.1}} }
 

--- a/spec/specwrk/worker/executor_spec.rb
+++ b/spec/specwrk/worker/executor_spec.rb
@@ -66,6 +66,26 @@ RSpec.describe Specwrk::Worker::Executor do
 
       expect(instance.run(examples)).to eq("🇺🇸!Big Success!🇺🇸")
     end
+
+    it "runs before_worker_examples_execute before interacting with the runner and yields the examples" do
+      calls = []
+      allow(instance).to receive(:reset!)
+      allow(RSpec::Core::ConfigurationOptions).to receive(:new).and_return(options_dbl)
+      allow(RSpec::Core::Runner).to receive(:new).with(options_dbl) do
+        calls << :runner
+        runner_dbl
+      end
+      allow(runner_dbl).to receive(:run)
+      Specwrk.before_worker_examples_execute do |hook_examples|
+        calls << [:hook, hook_examples]
+      end
+
+      instance.run(examples)
+
+      expect(calls[0][0]).to eq(:hook)
+      expect(calls[0][1]).to be(examples)
+      expect(calls[1]).to eq(:runner)
+    end
   end
 
   describe "#reset!" do

--- a/spec/specwrk/worker/executor_spec.rb
+++ b/spec/specwrk/worker/executor_spec.rb
@@ -86,6 +86,25 @@ RSpec.describe Specwrk::Worker::Executor do
       expect(calls[0][1]).to be(examples)
       expect(calls[1]).to eq(:runner)
     end
+
+    it "runs after_worker_examples_execute after the runner and yields the examples" do
+      calls = []
+      allow(instance).to receive(:reset!)
+      allow(RSpec::Core::ConfigurationOptions).to receive(:new).and_return(options_dbl)
+      allow(RSpec::Core::Runner).to receive(:new).with(options_dbl).and_return(runner_dbl)
+      allow(runner_dbl).to receive(:run) do
+        calls << :runner
+        :runner_result
+      end
+      Specwrk.after_worker_examples_execute do |hook_examples|
+        calls << [:hook, hook_examples]
+      end
+
+      expect(instance.run(examples)).to eq(:runner_result)
+      expect(calls[0]).to eq(:runner)
+      expect(calls[1][0]).to eq(:hook)
+      expect(calls[1][1]).to be(examples)
+    end
   end
 
   describe "#reset!" do

--- a/spec/specwrk_spec.rb
+++ b/spec/specwrk_spec.rb
@@ -40,6 +40,23 @@ RSpec.describe Specwrk do
     end
   end
 
+  describe ".before_server_seed" do
+    it "registers a before_server_seed hook and returns the block" do
+      calls = []
+      hook = proc { calls << :called }
+
+      expect(described_class.before_server_seed(&hook)).to be(hook)
+
+      Specwrk::Hooks.run(:before_server_seed)
+      expect(calls).to eq([:called])
+    end
+
+    it "requires a block" do
+      expect { described_class.before_server_seed }
+        .to raise_error(ArgumentError, "a block is required")
+    end
+  end
+
   describe ".before_worker_fork" do
     it "registers a before_worker_fork hook and returns the block" do
       calls = []

--- a/spec/specwrk_spec.rb
+++ b/spec/specwrk_spec.rb
@@ -22,6 +22,24 @@ RSpec.describe Specwrk do
     end
   end
 
+  describe ".after_seed" do
+    it "registers an after_seed hook and returns the block" do
+      examples = Object.new
+      received = nil
+      hook = proc { |value| received = value }
+
+      expect(described_class.after_seed(&hook)).to be(hook)
+
+      Specwrk::Hooks.run(:after_seed, examples)
+      expect(received).to be(examples)
+    end
+
+    it "requires a block" do
+      expect { described_class.after_seed }
+        .to raise_error(ArgumentError, "a block is required")
+    end
+  end
+
   describe ".wait_for_pids_exit" do
     subject { described_class.wait_for_pids_exit(pids) }
 

--- a/spec/specwrk_spec.rb
+++ b/spec/specwrk_spec.rb
@@ -128,6 +128,24 @@ RSpec.describe Specwrk do
     end
   end
 
+  describe ".after_all_workers_exit" do
+    it "registers an after_all_workers_exit hook and returns the block" do
+      status = Object.new
+      received = nil
+      hook = proc { |value| received = value }
+
+      expect(described_class.after_all_workers_exit(&hook)).to be(hook)
+
+      Specwrk::Hooks.run(:after_all_workers_exit, status)
+      expect(received).to be(status)
+    end
+
+    it "requires a block" do
+      expect { described_class.after_all_workers_exit }
+        .to raise_error(ArgumentError, "a block is required")
+    end
+  end
+
   describe ".wait_for_pids_exit" do
     subject { described_class.wait_for_pids_exit(pids) }
 

--- a/spec/specwrk_spec.rb
+++ b/spec/specwrk_spec.rb
@@ -74,6 +74,24 @@ RSpec.describe Specwrk do
     end
   end
 
+  describe ".before_worker_examples_execute" do
+    it "registers a before_worker_examples_execute hook and returns the block" do
+      examples = Object.new
+      received = nil
+      hook = proc { |value| received = value }
+
+      expect(described_class.before_worker_examples_execute(&hook)).to be(hook)
+
+      Specwrk::Hooks.run(:before_worker_examples_execute, examples)
+      expect(received).to be(examples)
+    end
+
+    it "requires a block" do
+      expect { described_class.before_worker_examples_execute }
+        .to raise_error(ArgumentError, "a block is required")
+    end
+  end
+
   describe ".wait_for_pids_exit" do
     subject { described_class.wait_for_pids_exit(pids) }
 

--- a/spec/specwrk_spec.rb
+++ b/spec/specwrk_spec.rb
@@ -110,6 +110,24 @@ RSpec.describe Specwrk do
     end
   end
 
+  describe ".before_worker_exit" do
+    it "registers a before_worker_exit hook and returns the block" do
+      status = Object.new
+      received = nil
+      hook = proc { |value| received = value }
+
+      expect(described_class.before_worker_exit(&hook)).to be(hook)
+
+      Specwrk::Hooks.run(:before_worker_exit, status)
+      expect(received).to be(status)
+    end
+
+    it "requires a block" do
+      expect { described_class.before_worker_exit }
+        .to raise_error(ArgumentError, "a block is required")
+    end
+  end
+
   describe ".wait_for_pids_exit" do
     subject { described_class.wait_for_pids_exit(pids) }
 

--- a/spec/specwrk_spec.rb
+++ b/spec/specwrk_spec.rb
@@ -57,6 +57,24 @@ RSpec.describe Specwrk do
     end
   end
 
+  describe ".after_server_seed" do
+    it "registers an after_server_seed hook and returns the block" do
+      examples = Object.new
+      received = nil
+      hook = proc { |value| received = value }
+
+      expect(described_class.after_server_seed(&hook)).to be(hook)
+
+      Specwrk::Hooks.run(:after_server_seed, examples)
+      expect(received).to be(examples)
+    end
+
+    it "requires a block" do
+      expect { described_class.after_server_seed }
+        .to raise_error(ArgumentError, "a block is required")
+    end
+  end
+
   describe ".before_worker_fork" do
     it "registers a before_worker_fork hook and returns the block" do
       calls = []

--- a/spec/specwrk_spec.rb
+++ b/spec/specwrk_spec.rb
@@ -57,6 +57,23 @@ RSpec.describe Specwrk do
     end
   end
 
+  describe ".after_worker_fork" do
+    it "registers an after_worker_fork hook and returns the block" do
+      calls = []
+      hook = proc { calls << :called }
+
+      expect(described_class.after_worker_fork(&hook)).to be(hook)
+
+      Specwrk::Hooks.run(:after_worker_fork)
+      expect(calls).to eq([:called])
+    end
+
+    it "requires a block" do
+      expect { described_class.after_worker_fork }
+        .to raise_error(ArgumentError, "a block is required")
+    end
+  end
+
   describe ".wait_for_pids_exit" do
     subject { described_class.wait_for_pids_exit(pids) }
 

--- a/spec/specwrk_spec.rb
+++ b/spec/specwrk_spec.rb
@@ -5,6 +5,23 @@ RSpec.describe Specwrk do
     expect(Specwrk::VERSION).not_to be nil
   end
 
+  describe ".before_seed" do
+    it "registers a before_seed hook and returns the block" do
+      calls = []
+      hook = proc { calls << :called }
+
+      expect(described_class.before_seed(&hook)).to be(hook)
+
+      Specwrk::Hooks.run(:before_seed)
+      expect(calls).to eq([:called])
+    end
+
+    it "requires a block" do
+      expect { described_class.before_seed }
+        .to raise_error(ArgumentError, "a block is required")
+    end
+  end
+
   describe ".wait_for_pids_exit" do
     subject { described_class.wait_for_pids_exit(pids) }
 

--- a/spec/specwrk_spec.rb
+++ b/spec/specwrk_spec.rb
@@ -92,6 +92,24 @@ RSpec.describe Specwrk do
     end
   end
 
+  describe ".after_worker_examples_execute" do
+    it "registers an after_worker_examples_execute hook and returns the block" do
+      examples = Object.new
+      received = nil
+      hook = proc { |value| received = value }
+
+      expect(described_class.after_worker_examples_execute(&hook)).to be(hook)
+
+      Specwrk::Hooks.run(:after_worker_examples_execute, examples)
+      expect(received).to be(examples)
+    end
+
+    it "requires a block" do
+      expect { described_class.after_worker_examples_execute }
+        .to raise_error(ArgumentError, "a block is required")
+    end
+  end
+
   describe ".wait_for_pids_exit" do
     subject { described_class.wait_for_pids_exit(pids) }
 

--- a/spec/specwrk_spec.rb
+++ b/spec/specwrk_spec.rb
@@ -40,6 +40,23 @@ RSpec.describe Specwrk do
     end
   end
 
+  describe ".before_worker_fork" do
+    it "registers a before_worker_fork hook and returns the block" do
+      calls = []
+      hook = proc { calls << :called }
+
+      expect(described_class.before_worker_fork(&hook)).to be(hook)
+
+      Specwrk::Hooks.run(:before_worker_fork)
+      expect(calls).to eq([:called])
+    end
+
+    it "requires a block" do
+      expect { described_class.before_worker_fork }
+        .to raise_error(ArgumentError, "a block is required")
+    end
+  end
+
   describe ".wait_for_pids_exit" do
     subject { described_class.wait_for_pids_exit(pids) }
 


### PR DESCRIPTION
Add lifecycle hooks. There are opportunties for others as well.

| Hook Method | Description | Arguments |
| --- | --- | --- |
| `Specwrk.before_seed(&blk)` | Runs before seeding examples to the server | none |
| `Specwrk.after_seed(&blk)` | Runs after seeding examples to the server | `examples` RSpec examples |
| `Specwrk.before_server_seed(&blk)` | Runs in the server before seeding examples | none |
| `Specwrk.after_server_seed(&blk)` | Runs in the server after seeding examples | `examples` RSpec examples |
| `Specwrk.before_worker_fork(&blk)` | Runs in the parent process before spawning each worker | none |
| `Specwrk.after_worker_fork(&blk)` | Runs in each worker process immediately after it is spawned | none |
| `Specwrk.before_worker_examples_execute(&blk)` | Runs in a worker before an examples group is passed to the RSpec runner | `examples` RSpec examples in the group |
| `Specwrk.after_worker_examples_execute(&blk)` | Runs in a worker after an examples group is executed by the RSpec runner | `examples` RSpec examples in the group |
| `Specwrk.before_worker_exit(&blk)` | Runs in each worker after work completes and before the process exits | `status` Worker exit status |
| `Specwrk.after_all_workers_exit(&blk)` | Runs in the parent process after all workers exit | `status` Overall worker exit status |
